### PR TITLE
Use import destructuring spacing config option

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,14 @@
           "default": "Warnings",
           "description": "Defines the log output level in the output window."
         },
+        "typescriptHero.resolver.useImportDestructuringSpacing": {
+          "enum": [
+            false,
+            true
+          ],
+          "default": false,
+          "description": "Defines if there should be a space inside curly braces of import statements."
+        },
         "typescriptHero.resolver.pathStringDelimiter": {
           "enum": [
             "'",

--- a/src/ExtensionConfig.ts
+++ b/src/ExtensionConfig.ts
@@ -33,6 +33,10 @@ export class ExtensionConfig {
 }
 
 class ResolverConfig {
+    public get useImportDestructuringSpacing(): boolean {
+        return workspace.getConfiguration(sectionKey).get<boolean>('resolver.useImportDestructuringSpacing');
+    }
+
     public get pathStringDelimiter(): string {
         return workspace.getConfiguration(sectionKey).get<string>('resolver.pathStringDelimiter');
     }

--- a/src/extensions/ResolveExtension.ts
+++ b/src/extensions/ResolveExtension.ts
@@ -217,7 +217,7 @@ export class ResolveExtension extends BaseExtension {
                     builder.delete(line.rangeIncludingLineBreak);
                 }
             }
-            builder.insert(new vscode.Position(0, 0), imports.reduce((all, cur) => all += cur.toImport(this.config.resolver.pathStringDelimiter), ''));
+            builder.insert(new vscode.Position(0, 0), imports.reduce((all, cur) => all += cur.toImport(this.config.resolver.pathStringDelimiter, this.config.resolver.resolver.useImportDestructuringSpacing), ''));
         });
     }
 

--- a/src/extensions/ResolveExtension.ts
+++ b/src/extensions/ResolveExtension.ts
@@ -217,7 +217,7 @@ export class ResolveExtension extends BaseExtension {
                     builder.delete(line.rangeIncludingLineBreak);
                 }
             }
-            builder.insert(new vscode.Position(0, 0), imports.reduce((all, cur) => all += cur.toImport(this.config.resolver.pathStringDelimiter, this.config.resolver.resolver.useImportDestructuringSpacing), ''));
+            builder.insert(new vscode.Position(0, 0), imports.reduce((all, cur) => all += cur.toImport(this.config.resolver.pathStringDelimiter, this.config.resolver.useImportDestructuringSpacing), ''));
         });
     }
 

--- a/src/models/TsImport.ts
+++ b/src/models/TsImport.ts
@@ -3,7 +3,7 @@ import {TsResolveSpecifier} from './TsResolveSpecifier';
 export abstract class TsImport {
     constructor(public libraryName: string) { }
 
-    public abstract toImport(delimiter: string): string;
+    public abstract toImport(delimiter: string, useImportDestructuringSpacing?: boolean): string;
 }
 
 export abstract class TsAliasedImport extends TsImport {
@@ -13,7 +13,7 @@ export abstract class TsAliasedImport extends TsImport {
 }
 
 export class TsStringImport extends TsImport {
-    public toImport(delimiter: string): string {
+    public toImport(delimiter: string, useImportDestructuringSpacing?: boolean): string {
         return `import ${delimiter}${this.libraryName}${delimiter};\n`;
     }
 }
@@ -21,8 +21,8 @@ export class TsStringImport extends TsImport {
 export class TsNamedImport extends TsImport {
     public specifiers: TsResolveSpecifier[] = [];
 
-    public toImport(delimiter: string): string {
-        return `import {${this.specifiers.sort(this.specifierSort).map(o => o.toImport()).join(', ')}} from ${delimiter}${this.libraryName}${delimiter};\n`;
+    public toImport(delimiter: string, useImportDestructuringSpacing?: boolean): string {
+        return `import {${useImportDestructuringSpacing?' ':''}${this.specifiers.sort(this.specifierSort).map(o => o.toImport()).join(', ')}${useImportDestructuringSpacing?' ':''}} from ${delimiter}${this.libraryName}${delimiter};\n`;
     }
 
     private specifierSort(i1: TsResolveSpecifier, i2: TsResolveSpecifier): number {
@@ -39,19 +39,19 @@ export class TsNamedImport extends TsImport {
 }
 
 export class TsNamespaceImport extends TsAliasedImport {
-    public toImport(delimiter: string): string {
+    public toImport(delimiter: string, useImportDestructuringSpacing?: boolean): string {
         return `import * as ${this.alias} from ${delimiter}${this.libraryName}${delimiter};\n`;
     }
 }
 
 export class TsExternalModuleImport extends TsAliasedImport {
-    public toImport(delimiter: string): string {
+    public toImport(delimiter: string, useImportDestructuringSpacing?: boolean): string {
         return `import ${this.alias} = require(${delimiter}${this.libraryName}${delimiter});\n`;
     }
 }
 
 export class TsDefaultImport extends TsAliasedImport {
-    public toImport(delimiter: string): string {
+    public toImport(delimiter: string, useImportDestructuringSpacing?: boolean): string {
         return `import ${this.alias} from ${delimiter}${this.libraryName}${delimiter};\n`;
     }
 }


### PR DESCRIPTION
Added a config option that will put spaces inside the curly braces of imports.

This will satisfy the useImportDestructuringSpacing lint rule in [codelyzer](https://github.com/mgechev/codelyzer).