### PR TITLE
import symbol under cursor

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,10 @@
         "command": "typescriptHero.resolve.organizeImports",
         "key": "ctrl+alt+o",
         "when": "editorTextFocus"
+      },{
+        "command":"typescriptHero.resolve.importCurrentSymbol",
+        "key":"ctrl+shift+m",
+        "when": "editorTextFocus"
       }
     ],
     "configuration": {

--- a/src/extensions/ResolveExtension.ts
+++ b/src/extensions/ResolveExtension.ts
@@ -129,7 +129,6 @@ export class ResolveExtension extends BaseExtension {
             this.showCacheWarning();
             return;
         }
-        console.log(vscode.window.activeTextEditor.selection);
         let editor = vscode.window.activeTextEditor,
             selection = editor.selection,
             word = editor.document.getWordRangeAtPosition(selection.active),
@@ -137,9 +136,9 @@ export class ResolveExtension extends BaseExtension {
         if (!word.isEmpty) {
             searchText = editor.document.getText(word);
         }
-        this.pickProvider.buildQuickPickList(vscode.window.activeTextEditor.document.uri, vscode.window.activeTextEditor.document.getText(), searchText).then(items => {
+        this.pickProvider.buildQuickPickList(editor.document.uri, editor.document.getText(), searchText).then(items => {
             if (items.length > 1) {
-                this.pickProvider.addImportPick(vscode.window.activeTextEditor.document.uri, vscode.window.activeTextEditor.document.getText(), searchText).then(o => {
+                this.pickProvider.addImportPick(editor.document.uri, editor.document.getText(), searchText).then(o => {
                     if (o) {
                         this.addImportToDocument(o);
                     }

--- a/src/extensions/ResolveExtension.ts
+++ b/src/extensions/ResolveExtension.ts
@@ -130,12 +130,12 @@ export class ResolveExtension extends BaseExtension {
             return;
         }
         console.log(vscode.window.activeTextEditor.selection);
-        let selection = vscode.window.activeTextEditor.selection;
-        let document = vscode.window.activeTextEditor.document;
-        let word = document.getWordRangeAtPosition(selection.active);
-        let searchText: string;
+        let editor = vscode.window.activeTextEditor,
+            selection = editor.selection,
+            word = editor.document.getWordRangeAtPosition(selection.active),
+            searchText: string;
         if (!word.isEmpty) {
-            searchText = document.getText(word);
+            searchText = editor.document.getText(word);
         }
         this.pickProvider.buildQuickPickList(vscode.window.activeTextEditor.document.uri, vscode.window.activeTextEditor.document.getText(), searchText).then(items => {
             if (items.length > 1) {

--- a/src/provider/ResolveQuickPickProvider.ts
+++ b/src/provider/ResolveQuickPickProvider.ts
@@ -23,9 +23,7 @@ export class ResolveQuickPickProvider {
             .then(parsedSource => {
                 let resolveItems = this.resolveItemFactory.getResolvableItems(this.cache.cachedFiles, openDocument, parsedSource.imports);
                 if (search) {
-                    resolveItems = resolveItems.filter(item => {
-                        return item.declaration.name === search;
-                    });
+                    resolveItems = resolveItems.filter(item => item.declaration.name === search);
                 }
                 return resolveItems.map(o => new ResolveQuickPickItem(o));
             })

--- a/src/provider/ResolveQuickPickProvider.ts
+++ b/src/provider/ResolveQuickPickProvider.ts
@@ -14,14 +14,19 @@ export class ResolveQuickPickProvider {
         this.logger = loggerFactory('ResolveQuickPickProvider');
     }
 
-    public addImportPick(openDocument: vscode.Uri, openSource: string): Thenable<ResolveQuickPickItem> {
-        return vscode.window.showQuickPick(this.buildQuickPickList(openDocument, openSource));
+    public addImportPick(openDocument: vscode.Uri, openSource: string, searchText: string = ''): Thenable<ResolveQuickPickItem> {
+        return vscode.window.showQuickPick(this.buildQuickPickList(openDocument, openSource, searchText));
     }
 
-    private buildQuickPickList(openDocument: vscode.Uri, openSource: string): Thenable<ResolveQuickPickItem[]> {
+    public buildQuickPickList(openDocument: vscode.Uri, openSource: string, search: string = ''): Thenable<ResolveQuickPickItem[]> {
         return this.parser.parseSource(openSource)
             .then(parsedSource => {
                 let resolveItems = this.resolveItemFactory.getResolvableItems(this.cache.cachedFiles, openDocument, parsedSource.imports);
+                if (search) {
+                    resolveItems = resolveItems.filter(item => {
+                        return item.declaration.name === search;
+                    });
+                }
                 return resolveItems.map(o => new ResolveQuickPickItem(o));
             })
             .catch(error => {


### PR DESCRIPTION
I added the possibility to import the symbol currently under the cursor (ctrl+shift+m when the cursor is on the symbol).
It's not a clean way to do this (I changed a method from private to public, etc). But I didn't have time to dive deeply in the code. AFAIK, It works and I find this functionality very interesting. So maybe it would give you some ideas to implement this in a cleaner manner.

Thank you for this plugin.