### PR TITLE
Fix/windows slashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 #### Changed
 - Import under cursor does only import if it's an exact match (PR [#35](https://github.com/buehler/typescript-hero/pull/35))
 
+#### Fixed
+- On Windows, forwardslashes will be used instead of backslashes ([19](https://github.com/buehler/typescript-hero/issues/19)) (definitly this time)
+
 ## [0.6.0]
 #### Added
 - Command to add an import from a symbol under the current cursor ([#22](https://github.com/buehler/typescript-hero/issues/22))

--- a/src/extensions/ResolveExtension.ts
+++ b/src/extensions/ResolveExtension.ts
@@ -246,6 +246,7 @@ export class ResolveExtension extends BaseExtension {
                             if (!relativePath.startsWith('.')) {
                                 relativePath = './' + relativePath;
                             }
+                            relativePath = relativePath.replace(/\\/g, '/');
                             library = relativePath;
                         }
                         let named = new TsNamedImport(library);

--- a/src/models/TsResource.ts
+++ b/src/models/TsResource.ts
@@ -1,7 +1,7 @@
 import {TsDeclaration} from './TsDeclaration';
 import {TsExport} from './TsExport';
 import {TsImport} from './TsImport';
-import {parse, ParsedPath, sep} from 'path';
+import {parse, ParsedPath} from 'path';
 import {workspace} from 'vscode';
 
 // TsSource can be: File, Module, Namespace

--- a/src/models/TsResource.ts
+++ b/src/models/TsResource.ts
@@ -1,7 +1,7 @@
 import {TsDeclaration} from './TsDeclaration';
 import {TsExport} from './TsExport';
 import {TsImport} from './TsImport';
-import {parse, ParsedPath} from 'path';
+import {parse, ParsedPath, sep} from 'path';
 import {workspace} from 'vscode';
 
 // TsSource can be: File, Module, Namespace


### PR DESCRIPTION
Closes #19 

Libraryname had `\` in it. Replace all back with forwardslashes does the trick.