### PR TITLE
Fix/root index exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Autocomplete filters local file usages ([#69](https://github.com/buehler/typescript-hero/issues/69))
 - Default exports do not break extension anymore ([#79](https://github.com/buehler/typescript-hero/issues/79))
 - Node pathes are correctly split ([#76](https://github.com/buehler/typescript-hero/issues/76))
+- Exports from root index.ts are not empty
 
 ## [0.8.0]
 #### Added

--- a/src/caches/ResolveIndex.ts
+++ b/src/caches/ResolveIndex.ts
@@ -188,7 +188,7 @@ export class ResolveIndex {
                 }
                 index[declaration.name].push({
                     declaration,
-                    from: key.replace(/[/]?index$/, '')
+                    from: key.replace(/[/]?index$/, '') || '/'
                 });
             }
         }


### PR DESCRIPTION
Fixes error that root (workspace root) index.ts files that exported other files (like in a library as [giuseppe](https://github.com/smartive/giuseppe)) did result in
`import {Get} from '';`