### PR TITLE
Feature/add all missing command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 #### Added
 - JSDOCS!
 - Code action provider (light bulb) that imports missing imports as a code fix ([#11](https://github.com/buehler/typescript-hero/issues/11))
+- Add all missing imports command ([#106](https://github.com/buehler/typescript-hero/issues/106))
 
 #### Changed
 - Documents are managed by a controller that calculates all edits first before committing the changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 #### Added
 - JSDOCS!
 - Code action provider (light bulb) that imports missing imports as a code fix ([#11](https://github.com/buehler/typescript-hero/issues/11))
-- Add all missing imports command ([#106](https://github.com/buehler/typescript-hero/issues/106))
+- Add all missing imports command usable through the gui or by command ([#106](https://github.com/buehler/typescript-hero/issues/106))
 
 #### Changed
 - Documents are managed by a controller that calculates all edits first before committing the changes

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Here is a brief list, of what TypeScript Hero is capable of:
 
 - Add imports of your project or libraries to your current file
 - Add an import for the current name under the cursor
+- Add all missing imports of a file with one command
 - Intellisense that suggests symbols and automatically adds the needed imports
+- "Light bulb feature" that fixes code you wrote (aka adds imports if you missed them, more to come.)
 - Sort and organize your imports (sort and remove unused)
 - Restart your debug session when your code changes
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ All commands are preceeded by `typescriptHero`.
 | showCmdGui                   | general         | Shows a small gui with all available internal commands    |
 | resolve.addImport            | import resolver | Shows a pick list with all recognized, importable symbols |
 | resolve.addImportUnderCursor | import resolver | Imports the symbol under the cursor                       |
+| resolve.addMissingImports    | import resolver | Imports all missing symbols for the actual document       |
 | resolve.organizeImports      | import resolver | Removes unused imports and orders all imports             |
 | resolve.rebuildCache         | import resolver | Rebuilds the whole symbol cache (or index)                |
 | restartDebugger.toggle       | debug restarter | Toggles the active state of the debug restarter           |

--- a/package.json
+++ b/package.json
@@ -87,6 +87,10 @@
         "title": "Typescript: Adds the current symbol under the cursor as an import to current file"
       },
       {
+        "command": "typescriptHero.resolve.addMissingImports",
+        "title": "Typescript: Adds all missing imports for the open document"
+      },
+      {
         "command": "typescriptHero.resolve.organizeImports",
         "title": "Typescript: Organize imports (sort and remove unused)"
       },

--- a/src/extensions/ResolveExtension.ts
+++ b/src/extensions/ResolveExtension.ts
@@ -93,6 +93,12 @@ export class ResolveExtension extends BaseExtension {
                 new TshCommand(() => this.addImportUnderCursor())
             ),
             new CommandQuickPickItem(
+                'Import resolver: Add missing imports',
+                '',
+                'Adds all missing symbols to the actual document if possible.',
+                new TshCommand(() => this.addMissingImports())
+            ),
+            new CommandQuickPickItem(
                 'Import resolver: Organize imports',
                 '',
                 'Sorts imports and removes unused imports.',
@@ -114,6 +120,11 @@ export class ResolveExtension extends BaseExtension {
         context.subscriptions.push(
             commands.registerTextEditorCommand(
                 'typescriptHero.resolve.addImportUnderCursor', () => this.addImportUnderCursor()
+            )
+        );
+        context.subscriptions.push(
+            commands.registerTextEditorCommand(
+                'typescriptHero.resolve.addMissingImports', () => this.addMissingImports()
             )
         );
         context.subscriptions.push(
@@ -226,6 +237,29 @@ export class ResolveExtension extends BaseExtension {
         } catch (e) {
             this.logger.error('An error happend during import picking', e);
             window.showErrorMessage('The import cannot be completed, there was an error during the process.');
+        }
+    }
+
+    /**
+     * Adds all missing imports to the actual document if possible. If multiple declarations are found,
+     * a quick pick list is shown to the user and he needs to decide, which import to use.
+     * 
+     * @private
+     * @returns {Promise<void>}
+     * 
+     * @memberOf ResolveExtension
+     */
+    private async addMissingImports(): Promise<void> {
+        if (!this.index.indexReady) {
+            this.showCacheWarning();
+            return;
+        }
+        try {
+            let ctrl = await DocumentController.create(window.activeTextEditor.document);
+            await ctrl.addMissingImports(this.index).commit();
+        } catch (e) {
+            this.logger.error('An error happend during import fixing', e);
+            window.showErrorMessage('The operation cannot be completed, there was an error during the process.');
         }
     }
 


### PR DESCRIPTION
- Closes #106

#### Description

Adds the "add all missing symbols / imports" command to the extension and make it accessable through the typescript-hero gui (ctrl alt g)