### PR TITLE
Fix/cannot cancel import missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 #### Fixed
 - All possible found declarations are listen in light-blub ([#123](https://github.com/buehler/typescript-hero/issues/123))
+- Removed "required" user answer ([#121](https://github.com/buehler/typescript-hero/issues/121))
 
 ## [0.10.0]
 #### Added

--- a/src/controllers/DocumentController.ts
+++ b/src/controllers/DocumentController.ts
@@ -316,7 +316,9 @@ export class DocumentController {
                 return all;
             }, []) as string[];
 
-        for (let decision of Object.keys(this.userImportDecisions)) {
+        for (let decision of Object.keys(
+            this.userImportDecisions
+        ).filter(o => this.userImportDecisions[o].length > 0)) {
             let declarations: ResolveQuickPickItem[] = this.userImportDecisions[decision].map(
                 o => new ResolveQuickPickItem(o)
             );

--- a/src/controllers/DocumentController.ts
+++ b/src/controllers/DocumentController.ts
@@ -356,11 +356,12 @@ export class DocumentController {
      * @memberOf DocumentController
      */
     private async getSpecifierAlias(): Promise<string> {
-        return this.vscodeInputBox({
+        let result = await this.vscodeInputBox({
             placeHolder: 'Alias for specifier',
             prompt: 'Please enter an alias for the specifier..',
             validateInput: s => !!s ? '' : 'Please enter a variable name'
         });
+        return !!result ? result : undefined;
     }
 
     /**
@@ -373,12 +374,13 @@ export class DocumentController {
      * @memberOf DocumentController
      */
     private async getDefaultIdentifier(declarationName: string): Promise<string> {
-        return this.vscodeInputBox({
+        let result = await this.vscodeInputBox({
             placeHolder: 'Default export name',
             prompt: 'Please enter a variable name for the default export..',
             validateInput: s => !!s ? '' : 'Please enter a variable name',
             value: declarationName
         });
+        return !!result ? result : undefined;
     }
 
     /**

--- a/src/controllers/DocumentController.ts
+++ b/src/controllers/DocumentController.ts
@@ -320,15 +320,14 @@ export class DocumentController {
             let declarations: ResolveQuickPickItem[] = this.userImportDecisions[decision].map(
                 o => new ResolveQuickPickItem(o)
             );
-            let result: ResolveQuickPickItem;
 
-            do {
-                result = await window.showQuickPick(declarations, {
-                    placeHolder: `Multiple declarations for "${decision}" found.`
-                });
-            } while (!!!result);
+            let result = await window.showQuickPick(declarations, {
+                placeHolder: `Multiple declarations for "${decision}" found.`
+            });
 
-            this.addDeclarationImport(result.declarationInfo);
+            if (result) {
+                this.addDeclarationImport(result.declarationInfo);
+            }
         }
 
         let proxies = this.imports.filter(o => o instanceof ImportProxy) as ImportProxy[];

--- a/src/controllers/DocumentController.ts
+++ b/src/controllers/DocumentController.ts
@@ -334,35 +334,33 @@ export class DocumentController {
 
         for (let imp of proxies) {
             if (imp.defaultPurposal && !imp.defaultAlias) {
-                imp.defaultAlias = await this.getDefaultIdentifier(imp.defaultPurposal, getSpecifiers());
+                imp.defaultAlias = await this.getDefaultIdentifier(imp.defaultPurposal);
                 delete imp.defaultPurposal;
             }
 
             for (let spec of imp.specifiers) {
                 let specifiers = getSpecifiers();
                 if (specifiers.filter(o => o === (spec.alias || spec.specifier)).length > 1) {
-                    spec.alias = await this.getSpecifierAlias(specifiers);
+                    spec.alias = await this.getSpecifierAlias();
                 }
             }
         }
     }
 
     /**
-     * Does resolve a duplicate specifier issue. Calls vscode inputbox as long as the inputted name
-     * does match the duplicates. (So the user needs to enter a different one)
+     * Does resolve a duplicate specifier issue.
      * 
      * @private
-     * @param {string} duplicate
      * @returns {Promise<string>}
      * 
      * @memberOf DocumentController
      */
-    private async getSpecifierAlias(specifiers: string[]): Promise<string> {
+    private async getSpecifierAlias(): Promise<string> {
         return this.vscodeInputBox({
             placeHolder: 'Alias for specifier',
             prompt: 'Please enter an alias for the specifier..',
             validateInput: s => !!s ? '' : 'Please enter a variable name'
-        }, alias => specifiers.indexOf(alias) >= 0);
+        });
     }
 
     /**
@@ -374,32 +372,25 @@ export class DocumentController {
      * 
      * @memberOf DocumentController
      */
-    private async getDefaultIdentifier(declarationName: string, specifiers: string[]): Promise<string> {
+    private async getDefaultIdentifier(declarationName: string): Promise<string> {
         return this.vscodeInputBox({
             placeHolder: 'Default export name',
             prompt: 'Please enter a variable name for the default export..',
             validateInput: s => !!s ? '' : 'Please enter a variable name',
             value: declarationName
-        }, alias => specifiers.indexOf(alias) >= 0);
+        });
     }
 
     /**
-     * Ultimately asks the user for an input. Does this, as long as the predicate function returns true.
+     * Ultimately asks the user for an input.
      * 
      * @private
      * @param {InputBoxOptions} options
-     * @param {() => boolean} predicate
      * @returns {Promise<string>}
      * 
      * @memberOf DocumentController
      */
-    private async vscodeInputBox(options: InputBoxOptions, predicate: (value: string) => boolean): Promise<string> {
-        let value: string;
-
-        do {
-            value = await window.showInputBox(options);
-        } while (predicate(value));
-
-        return value;
+    private async vscodeInputBox(options: InputBoxOptions): Promise<string> {
+        return await window.showInputBox(options);
     }
 }


### PR DESCRIPTION
- Fixes #121 
- Fixes #122 

#### Description

Does remove the requirement, that a user _has_ to answered questions. If an import decision (multiple declarations found on `addMissingImports`) is not answered, nothing happens. If a user does not give an alias for a specifier that is duplicated, it will simply write that import and the compiler will throw an error.

Also it does hopefully fix #122 which I can't test right now :-/ 