### PR TITLE
Fix/missing declarations - duplicate declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+#### Changed
+- Default value of `typescriptHero.resolver.ignorePatterns` does not contain node_modules anymore
+
 #### Fixed
 - Duplicate declarations are filtered (overloads from declarations) ([#105](https://github.com/buehler/typescript-hero/issues/105))
 - Only real workspace files are filtered by the exclude pattern (node_modules and typings are parsed) ([#103](https://github.com/buehler/typescript-hero/issues/103))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+#### Fixed
+- Duplicate declarations are filtered (overloads from declarations) ([#105](https://github.com/buehler/typescript-hero/issues/105))
+- Only real workspace files are filtered by the exclude pattern (node_modules and typings are parsed) ([#103](https://github.com/buehler/typescript-hero/issues/103))
 
 ## [0.11.0]
 #### Added

--- a/package.json
+++ b/package.json
@@ -164,10 +164,6 @@
           },
           "uniqueItems": true,
           "default": [
-            "typescript",
-            "tslint",
-            "node_modules/typings",
-            "node_modules/typings-core",
             "build",
             "out",
             "dist"

--- a/src/caches/ResolveIndex.ts
+++ b/src/caches/ResolveIndex.ts
@@ -288,12 +288,14 @@ export class ResolveIndex {
             return;
         }
         let excludePatterns = this.config.resolver.ignorePatterns;
-        uris = uris.map(o => o.filter(
-            f => f.fsPath
-                .replace(workspace.rootPath, '')
-                .split(/\\|\//)
-                .every(p => excludePatterns.indexOf(p) < 0)
-        ));
+        uris = uris.map((o, idx) => idx === 0 ?
+            o.filter(
+                f => f.fsPath
+                    .replace(workspace.rootPath, '')
+                    .split(/\\|\//)
+                    .every(p => excludePatterns.indexOf(p) < 0)) :
+            o
+        );
         this.logger.info(`Found ${uris.reduce((sum, cur) => sum + cur.length, 0)} files.`);
         return uris.reduce((all, cur) => all.concat(cur), []);
     }

--- a/src/caches/ResolveIndex.ts
+++ b/src/caches/ResolveIndex.ts
@@ -381,10 +381,15 @@ export class ResolveIndex {
                 if (!index[declaration.name]) {
                     index[declaration.name] = [];
                 }
-                index[declaration.name].push({
-                    declaration,
-                    from: key.replace(/[/]?index$/, '') || '/'
-                });
+                let from = key.replace(/[/]?index$/, '') || '/';
+                if (!index[declaration.name].some(
+                    o => o.declaration.constructor === declaration.constructor && o.from === from
+                )) {
+                    index[declaration.name].push({
+                        declaration,
+                        from
+                    });
+                }
             }
         }
         return index;

--- a/test/_workspace/node_modules/some-lib/dist/SomeDeclaration.d.ts
+++ b/test/_workspace/node_modules/some-lib/dist/SomeDeclaration.d.ts
@@ -1,0 +1,4 @@
+export declare class NestedDistDeclaration {
+    constrcutor();
+    public itDoesSomething(): Promise<void>;
+}

--- a/test/caches/ResolveIndex.test.ts
+++ b/test/caches/ResolveIndex.test.ts
@@ -81,6 +81,12 @@ describe('ResolveIndex', () => {
             list[1].declaration.should.be.an.instanceof(ClassDeclaration);
         });
 
+        it('should not contain a duplicate declaration (overloaded declarations)', () => {
+            let list = resolveIndex.index['execFile'];
+            list.should.be.an('array').with.lengthOf(1);
+            list[0].from.should.equal('child_process');
+        });
+
         it('should export * as correctly', () => {
             let idx: any = resolveIndex,
                 resources = idx.parsedResources;

--- a/test/caches/ResolveIndex.test.ts
+++ b/test/caches/ResolveIndex.test.ts
@@ -115,6 +115,12 @@ describe('ResolveIndex', () => {
             resources['/MyReactTemplate'].declarations[0].name.should.equal('myComponent');
         });
 
+        it('should not filter node_modules / typings by pattern', () => {
+            let list = resolveIndex.index['NestedDistDeclaration'];
+            list.should.be.an('array').with.lengthOf(1);
+            list[0].from.should.equal('some-lib/dist/SomeDeclaration');
+        });
+
     });
 
 });

--- a/test/caches/ResolveIndex.test.ts
+++ b/test/caches/ResolveIndex.test.ts
@@ -121,6 +121,11 @@ describe('ResolveIndex', () => {
             list[0].from.should.equal('some-lib/dist/SomeDeclaration');
         });
 
+        it('should not contain filtered directories', () => {
+            let list = resolveIndex.index['MyCompiledClass'];
+            list.should.be.an('array').with.lengthOf(0);
+        });
+
     });
 
 });

--- a/test/caches/ResolveIndex.test.ts
+++ b/test/caches/ResolveIndex.test.ts
@@ -4,7 +4,7 @@ import { Injector } from '../../src/IoC';
 import { ClassDeclaration, FunctionDeclaration } from '../../src/models/TsDeclaration';
 import * as chai from 'chai';
 
-chai.should();
+let should = chai.should();
 
 describe('ResolveIndex', () => {
 
@@ -123,7 +123,7 @@ describe('ResolveIndex', () => {
 
         it('should not contain filtered directories', () => {
             let list = resolveIndex.index['MyCompiledClass'];
-            list.should.be.an('array').with.lengthOf(0);
+            should.not.exist(list);
         });
 
     });


### PR DESCRIPTION
- Fixes #105
- Fixes #103

#### Description

- Changes the default value of `typescriptHero.resolver.ignorePatterns`
- Does filter declarations that have the same name, type and source library
- Do not filter node_modules / typings folders with ignorePatterns