### PR TITLE
Feature/add setting to configure semicolon insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 #### Changed
 - Default value of `typescriptHero.resolver.ignorePatterns` does not contain node_modules anymore
+- Added setting `typescriptHero.resolver.insertSemicolons` to make disabling of semicolon emit possible (defaults to true)
 
 #### Fixed
 - Duplicate declarations are filtered (overloads from declarations) ([#105](https://github.com/buehler/typescript-hero/issues/105))

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The following settings do have the prefix `resolver`. So an example setting coul
 | pathStringDelimiter                   | The string delimiter to use for the imports                                          |
 | ignorePatterns                        | If any of these strings is part of a file path, the file is ignored                  |
 | insertSpaceBeforeAndAfterImportBraces | If the extension should place spaces into import braces (`{Symbol}` vs `{ Symbol }`) |
+| insertSemicolons                      | If the extension should add a semicolon to the end of a statement                    |
 | multiLineWrapThreshold                | The threshold, when imports are converted into multiline imports                     |
 | newImportLocation                     | The location of new imports (at the top of the file, or at the cursor location)      |
 

--- a/package.json
+++ b/package.json
@@ -149,6 +149,11 @@
           "default": true,
           "description": "Defines if there should be a space inside the curly braces of an import statement."
         },
+        "typescriptHero.resolver.insertSemicolons": {
+          "type": "boolean",
+          "default": true,
+          "description": "Defines if there should be a semicolon at the end of a statement."
+        },
         "typescriptHero.resolver.pathStringDelimiter": {
           "enum": [
             "'",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "inversify": "^2.0.0",
     "inversify-inject-decorators": "^2.0.0",
     "reflect-metadata": "^0.1.8",
-    "typescript": "^2.0.3"
+    "typescript": "~2.0.3"
   },
   "activationEvents": [
     "onCommand:typescriptHero.showCmdGui",

--- a/src/ExtensionConfig.ts
+++ b/src/ExtensionConfig.ts
@@ -80,6 +80,18 @@ class ResolverConfig {
     }
 
     /**
+     * Defines, if there should be a semicolon at the end of a statement.
+     * import Symbol from 'symbol' vs import Symbol from 'symbol';
+     * 
+     * @readonly
+     * @type {boolean}
+     * @memberOf ResolverConfig
+     */
+    public get insertSemicolons(): boolean {
+        return workspace.getConfiguration(sectionKey).get<boolean>('resolver.insertSemicolons');
+    }
+
+    /**
      * Defines the quote style (' or ").
      * 
      * @readonly
@@ -145,6 +157,7 @@ class ResolverConfig {
      */
     public get importOptions(): TsImportOptions {
         return {
+            eol: this.insertSemicolons ? ';' : '',
             multiLineWrapThreshold: this.multiLineWrapThreshold,
             pathDelimiter: this.pathStringDelimiter,
             spaceBraces: this.insertSpaceBeforeAndAfterImportBraces,

--- a/src/models/TsImport.ts
+++ b/src/models/TsImport.ts
@@ -89,8 +89,8 @@ export class TsStringImport extends TsImport {
      * 
      * @memberOf TsStringImport
      */
-    public toImport({pathDelimiter}: TsImportOptions): string {
-        return `import ${pathDelimiter}${this.libraryName}${pathDelimiter};\n`;
+    public toImport({pathDelimiter, eol}: TsImportOptions): string {
+        return `import ${pathDelimiter}${this.libraryName}${pathDelimiter}${eol}\n`;
     }
 
     /**
@@ -126,12 +126,12 @@ export class TsNamedImport extends TsImport {
      * @memberOf TsNamedImport
      */
     public toImport(options: TsImportOptions): string {
-        let {pathDelimiter, spaceBraces, multiLineWrapThreshold} = options,
+        let {eol, pathDelimiter, spaceBraces, multiLineWrapThreshold} = options,
             space = spaceBraces ? ' ' : '',
             specifiers = this.specifiers.sort(this.specifierSort).map(o => o.toImport()).join(', '),
             lib = this.libraryName;
 
-        let importString = `import {${space}${specifiers}${space}} from ${pathDelimiter}${lib}${pathDelimiter};\n`;
+        let importString = `import {${space}${specifiers}${space}} from ${pathDelimiter}${lib}${pathDelimiter}${eol}\n`;
         if (importString.length > multiLineWrapThreshold) {
             return this.toMultiLineImport(options);
         }
@@ -159,11 +159,11 @@ export class TsNamedImport extends TsImport {
      * 
      * @memberOf TsNamedImport
      */
-    public toMultiLineImport({pathDelimiter, tabSize}: TsImportOptions): string {
+    public toMultiLineImport({eol, pathDelimiter, tabSize}: TsImportOptions): string {
         let spacings = Array(tabSize + 1).join(' ');
         return `import {
 ${this.specifiers.sort(this.specifierSort).map(o => `${spacings}${o.toImport()}`).join(',\n')}
-} from ${pathDelimiter}${this.libraryName}${pathDelimiter};\n`;
+} from ${pathDelimiter}${this.libraryName}${pathDelimiter}${eol}\n`;
     }
 
     /**
@@ -205,8 +205,8 @@ export class TsNamespaceImport extends TsAliasedImport {
      * 
      * @memberOf TsStringImport
      */
-    public toImport({pathDelimiter}: TsImportOptions): string {
-        return `import * as ${this.alias} from ${pathDelimiter}${this.libraryName}${pathDelimiter};\n`;
+    public toImport({eol, pathDelimiter}: TsImportOptions): string {
+        return `import * as ${this.alias} from ${pathDelimiter}${this.libraryName}${pathDelimiter}${eol}\n`;
     }
 
     /**
@@ -238,8 +238,8 @@ export class TsExternalModuleImport extends TsAliasedImport {
      * 
      * @memberOf TsStringImport
      */
-    public toImport({pathDelimiter}: TsImportOptions): string {
-        return `import ${this.alias} = require(${pathDelimiter}${this.libraryName}${pathDelimiter});\n`;
+    public toImport({eol, pathDelimiter}: TsImportOptions): string {
+        return `import ${this.alias} = require(${pathDelimiter}${this.libraryName}${pathDelimiter})${eol}\n`;
     }
 
     /**
@@ -271,8 +271,8 @@ export class TsDefaultImport extends TsAliasedImport {
      * 
      * @memberOf TsStringImport
      */
-    public toImport({pathDelimiter}: TsImportOptions): string {
-        return `import ${this.alias} from ${pathDelimiter}${this.libraryName}${pathDelimiter};\n`;
+    public toImport({eol, pathDelimiter}: TsImportOptions): string {
+        return `import ${this.alias} from ${pathDelimiter}${this.libraryName}${pathDelimiter}${eol}\n`;
     }
 
     /**

--- a/src/models/TsImportOptions.ts
+++ b/src/models/TsImportOptions.ts
@@ -5,12 +5,14 @@
  * @typedef TsImportOptions
  * 
  * @property {string} pathDelimiter - Which quote type should be used (' or ").
+ * @property {string} eol - Defines end of line character (semicolon or nothing) 
  * @property {boolean} spaceBraces - Defines if the symbols should have spacing in the braces ({ Foo } or {Foo}).
  * @property {number} multiLineWrapThreshold - The threshold where an import is written as multiline.
  * @property {number} tabSize - How many spaces of indentiation.
  */
 export type TsImportOptions = {
     pathDelimiter: string,
+    eol: '' | ';',
     spaceBraces: boolean,
     multiLineWrapThreshold: number,
     tabSize: number

--- a/test/models/ImportProxy.test.ts
+++ b/test/models/ImportProxy.test.ts
@@ -166,6 +166,7 @@ describe('ImportProxy', () => {
     describe('toImport()', () => {
 
         const options: TsImportOptions = {
+            eol: ';',
             multiLineWrapThreshold: 120,
             pathDelimiter: `'`,
             spaceBraces: true,
@@ -198,6 +199,13 @@ describe('ImportProxy', () => {
             proxy.defaultAlias = 'ALIAS';
             proxy.addSpecifier('bar');
             proxy.toImport(options).should.equal(`import { bar, default as ALIAS } from 'foo';\n`);
+        });
+
+        it('should ommit semicolons if configured', () => {
+            const optionsClone = Object.assign({}, options);
+            optionsClone.eol = '';
+            proxy.defaultAlias = 'ALIAS';
+            proxy.toImport(optionsClone).should.equal(`import ALIAS from 'foo'\n`);
         });
 
     });

--- a/test/models/ImportProxy.test.ts
+++ b/test/models/ImportProxy.test.ts
@@ -201,7 +201,7 @@ describe('ImportProxy', () => {
             proxy.toImport(options).should.equal(`import { bar, default as ALIAS } from 'foo';\n`);
         });
 
-        it('should ommit semicolons if configured', () => {
+        it('should omit semicolons if configured', () => {
             const optionsClone = Object.assign({}, options);
             optionsClone.eol = '';
             proxy.defaultAlias = 'ALIAS';


### PR DESCRIPTION

- Closes #146

#### Description

This PR adds the boolean setting `typescriptHero.resolver.insertSemicolons` which allows enabling or disabling the emit of a semicolon at the end of each generated line.

Internally it adds the `eol` string-option to the `TsImportOptions` interface by using the type `'' | ';'`
I'm not very happy with the name `eol` and maybe it's cleaner to pass the boolean setting down and if/else at each emit - but with the current implementation it's as easy as replacing the previous semicolon the new new eol variable.

I will update the PR to match the preferences of the extensions author of course.