### PR TITLE
Fix/console-log-import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 #### Fixed
 - Duplicate declarations are filtered (overloads from declarations) ([#105](https://github.com/buehler/typescript-hero/issues/105))
 - Only real workspace files are filtered by the exclude pattern (node_modules and typings are parsed) ([#103](https://github.com/buehler/typescript-hero/issues/103))
+- Variables are sorted to the top to reduce auto import for `console` ([#99](https://github.com/buehler/typescript-hero/issues/99))
 
 ## [0.11.0]
 #### Added

--- a/src/models/TsDeclaration.ts
+++ b/src/models/TsDeclaration.ts
@@ -41,6 +41,17 @@ export abstract class TsDeclaration extends TsNode {
      */
     public abstract readonly itemKind: CompletionItemKind;
 
+    /**
+     * Returns the default sorting key for the autocompletion feature.
+     * 
+     * @readonly
+     * @type {string}
+     * @memberOf TsDeclaration
+     */
+    public get intellisenseSortKey(): string {
+        return `0_${this.name}`;
+    }
+
     constructor(public name: string, start?: number, end?: number) {
         super(start, end);
     }
@@ -317,6 +328,10 @@ export class EnumDeclaration extends TsExportableDeclaration {
 export class VariableDeclaration extends TsTypedExportableDeclaration {
     public get itemKind(): CompletionItemKind {
         return CompletionItemKind.Variable;
+    }
+
+    public get intellisenseSortKey(): string {
+        return `1_${this.name}`;
     }
 
     constructor(

--- a/src/provider/ResolveCompletionItemProvider.ts
+++ b/src/provider/ResolveCompletionItemProvider.ts
@@ -97,6 +97,7 @@ export class ResolveCompletionItemProvider implements CompletionItemProvider {
             .map(o => {
                 let item = new CompletionItem(o.declaration.name, o.declaration.itemKind);
                 item.detail = o.from;
+                item.sortText = o.declaration.intellisenseSortKey;
                 item.additionalTextEdits = this.calculateTextEdits(o, document, parsed);
                 return item;
             });


### PR DESCRIPTION
- Fixes #99

#### Description

It _should_ ™️ fix the auto import of console.log -> it sortes the variable to the top.