### PR TITLE
Fix/ext crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Duplicate declarations are filtered (overloads from declarations) ([#105](https://github.com/buehler/typescript-hero/issues/105))
 - Only real workspace files are filtered by the exclude pattern (node_modules and typings are parsed) ([#103](https://github.com/buehler/typescript-hero/issues/103))
 - Variables are sorted to the top to reduce auto import for `console` ([#99](https://github.com/buehler/typescript-hero/issues/99))
+- Extension does not crash with prototype methods (thanks @gund) ([#79](https://github.com/buehler/typescript-hero/issues/79))
 
 ## [0.11.0]
 #### Added

--- a/src/caches/ResolveIndex.ts
+++ b/src/caches/ResolveIndex.ts
@@ -55,7 +55,7 @@ export class ResolveIndex {
     private logger: Logger;
     private cancelToken: CancellationTokenSource;
 
-    private parsedResources: Resources;
+    private parsedResources: Resources = {};
     private _index: ResourceIndex;
 
     /**

--- a/src/caches/ResolveIndex.ts
+++ b/src/caches/ResolveIndex.ts
@@ -55,7 +55,7 @@ export class ResolveIndex {
     private logger: Logger;
     private cancelToken: CancellationTokenSource;
 
-    private parsedResources: Resources = {};
+    private parsedResources: Resources = Object.create(null);
     private _index: ResourceIndex;
 
     /**
@@ -369,7 +369,9 @@ export class ResolveIndex {
             return;
         }
 
-        let index: ResourceIndex = {};
+        // Use an empty object without a prototype, so that "toString" (for example) can be indexed
+        // Thanks to @gund in https://github.com/buehler/typescript-hero/issues/79
+        let index: ResourceIndex = Object.create(null);
 
         for (let key of Object.keys(resources)) {
             let resource = resources[key];

--- a/test/_workspace/prototypeFunctions/proto.ts
+++ b/test/_workspace/prototypeFunctions/proto.ts
@@ -1,0 +1,7 @@
+export function toString(): string {
+    return '';
+}
+
+export function hasOwnProperty(): boolean {
+    return false;
+}

--- a/test/caches/ResolveIndex.test.ts
+++ b/test/caches/ResolveIndex.test.ts
@@ -126,6 +126,16 @@ describe('ResolveIndex', () => {
             should.not.exist(list);
         });
 
+        it('should not crash on prototype methods (i.e. toString, hasOwnProperty)', () => {
+            let list = resolveIndex.index['toString'];
+            list.should.be.an('array').with.lengthOf(1);
+            list[0].from.should.equal('/prototypeFunctions/proto');
+
+            let list2 = resolveIndex.index['hasOwnProperty'];
+            list2.should.be.an('array').with.lengthOf(1);
+            list2[0].from.should.equal('/prototypeFunctions/proto');
+        });
+
     });
 
 });


### PR DESCRIPTION
- Fixes #79 🎉 

#### Description

Thanks to @gund and his investigations: Prototype methods like `toString` or `hasOwnProperty` were existing on the index hash. So when checking for `if(!index[declaration.name])` the check returned true instead of false. 

Creating an empty object without a prototype does resolve this error (`Object.create(null)`)