### PR TITLE
Imports from newly added tsx files aren't seen by resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+#### Fixed
+- Imports from newly added tsx files aren't seen by resolver ([#169](https://github.com/buehler/typescript-hero/pull/169))
 
 ## [0.12.0]
 #### Added

--- a/src/extensions/ResolveExtension.ts
+++ b/src/extensions/ResolveExtension.ts
@@ -63,7 +63,7 @@ export class ResolveExtension extends BaseExtension {
     private logger: Logger;
     private statusBarItem: StatusBarItem = window.createStatusBarItem(StatusBarAlignment.Left, 4);
     private fileWatcher: FileSystemWatcher = workspace.createFileSystemWatcher(
-        '{**/*.ts,**/package.json,**/typings.json}', true
+        '{**/*.ts,**/*.tsx,**/package.json,**/typings.json}', true
     );
     private ignorePatterns: string[];
 


### PR DESCRIPTION
This fixes a bug where changes in new tsx files aren't seen by the resolver. So for example, if you added a new tsx file, then created a new exported class, that class wouldn't currently be seen by the resolver.

The workaround was to manually restart the resolver, but this change seems to fix the issue in my local testing (it seems this was just an oversight when support for tsx files was added).