### PR TITLE
#166 make imports sorting optional during organize imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The following settings do have the prefix `resolver`. So an example setting coul
 | insertSemicolons                      | If the extension should add a semicolon to the end of a statement                    |
 | multiLineWrapThreshold                | The threshold, when imports are converted into multiline imports                     |
 | newImportLocation                     | The location of new imports (at the top of the file, or at the cursor location)      |
+| disableImportsSorting                 | Disable sorting during organize imports action
 
 ### Debug session restarter
 

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
         },
         "typescriptHero.resolver.disableImportsSorting": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Defines if sorting is disable during organize imports"
         },
         "typescriptHero.restartDebugger.watchFolders": {

--- a/package.json
+++ b/package.json
@@ -190,6 +190,11 @@
           "default": "TopOfFile",
           "description": "Defines the location of new imports."
         },
+        "typescriptHero.resolver.disableImportsSorting": {
+          "type": "boolean",
+          "default": false,
+          "description": "Defines if sorting is disable during organize imports"
+        },
         "typescriptHero.restartDebugger.watchFolders": {
           "type": "array",
           "items": {

--- a/src/ExtensionConfig.ts
+++ b/src/ExtensionConfig.ts
@@ -138,6 +138,17 @@ class ResolverConfig {
     }
 
     /**
+     * Defines, if sorting is obligatory during organize imports
+     * 
+     * @readonly
+     * @type {boolean}
+     * @memberOf ResolverConfig
+     */
+    public get disableImportsSorting(): boolean {
+        return workspace.getConfiguration(sectionKey).get<boolean>('resolver.disableImportsSorting');
+    }
+
+    /**
      * Returns the tab size that is configured in vscode.
      * 
      * @readonly

--- a/src/managers/ImportManager.ts
+++ b/src/managers/ImportManager.ts
@@ -234,10 +234,12 @@ export class ImportManager implements ObjectManager {
             }
         }
 
-        keep = [
-            ...keep.filter(o => o instanceof TsStringImport).sort(importSort),
-            ...keep.filter(o => !(o instanceof TsStringImport)).sort(importSort)
-        ];
+        if (!ImportManager.config.resolver.disableImportsSorting) {
+            keep = [
+                ...keep.filter(o => o instanceof TsStringImport).sort(importSort),
+                ...keep.filter(o => !(o instanceof TsStringImport)).sort(importSort)
+            ];
+        }
 
         this.imports = keep;
 


### PR DESCRIPTION
I added `disableImportsSorting` setting which resolve #166

I have problems with unit tests, because right now they don't pass, and I supposed that providing structure for configuration mock services is part of refactor which you mention. 

