### PR TITLE
178 duplicate folder path for angular specific imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 #### Fixed
 - Imports from newly added tsx files aren't seen by resolver ([#169](https://github.com/buehler/typescript-hero/pull/169))
+- Imports from modules with index file as the same name as containing folder no longer double up import path (i.e. Angular)
+- Files without exports are no longer added to the index
 
 ## [0.12.0]
 #### Added

--- a/src/caches/ResolveIndex.ts
+++ b/src/caches/ResolveIndex.ts
@@ -40,7 +40,7 @@ function getNodeLibraryName(path: string): string {
 
     return dirs.slice(nodeIndex + 1).join('/')
         .replace(/([.]d)?([.]tsx?)?/g, '')
-        .replace(new RegExp(`/(index|${dirs[nodeIndex + 1]})$`), '');
+        .replace(new RegExp(`/(index|${dirs[nodeIndex + 1]}|${dirs[dirs.length - 2]})$`), '');
 }
 
 /**

--- a/src/caches/ResolveIndex.ts
+++ b/src/caches/ResolveIndex.ts
@@ -418,7 +418,7 @@ export class ResolveIndex {
         resource: TsResource,
         processedResources: TsResource[] = []
     ): void {
-        if (processedResources.indexOf(resource) >= 0 || resource.exports.length == 0) {
+        if (processedResources.indexOf(resource) >= 0 || resource.exports.length === 0) {
             return;
         }
         processedResources.push(resource);

--- a/src/caches/ResolveIndex.ts
+++ b/src/caches/ResolveIndex.ts
@@ -418,7 +418,7 @@ export class ResolveIndex {
         resource: TsResource,
         processedResources: TsResource[] = []
     ): void {
-        if (processedResources.indexOf(resource) >= 0) {
+        if (processedResources.indexOf(resource) >= 0 || resource.exports.length == 0) {
             return;
         }
         processedResources.push(resource);


### PR DESCRIPTION
- Fixes #178 

#### Description

Modules using a file with the same name as the containing folder as their index.d.ts no longer duplicate folder path. 


**Before**: `@angular/core/core.d.ts` -> `@angular/core/core` when imported
**After**: `@angular/core/core.d.ts` -> `@angular/core` when imported

With the tests it is difficult to distinguish what is broken due to the currently failing build. If you have a workaround for that, please let me know because I would love to contribute more.