### PR TITLE
add ability to define imports order (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Add `sort` settings that help fine-tune imports ordering ([#102](https://github.com/buehler/typescript-hero/issues/102))
 
 ## [0.13.0]
 ### Big refactoring.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ The following settings do have the prefix `resolver`. So an example setting coul
 | newImportLocation                     | The location of new imports (at the top of the file, or at the cursor location)      |
 | disableImportSorting                  | Disable sorting during organize imports action                                       |
 
+### Imports ordering
+
+The following settings have prefix `sort`. For example `typescriptHero.sort.type`
+
+| Setting                               | Description                                                                          |
+| ------------------------------------- | ------------------------------------------------------------------------------------ |
+| type                                  | Defines how imports should be sorted (alphabetically or semanticaly)                 |
+| semantic                              | In case `type` is `semantic` defines order of different semantic blocks              |
+
 ## Features (extended)
 
 ### Import management

--- a/package.json
+++ b/package.json
@@ -190,6 +190,33 @@
           "type": "boolean",
           "default": false,
           "description": "Defines if sorting is disable during organize imports"
+        },
+        "typescriptHero.sort.type": {
+          "enum": [
+            "ascending",
+            "descending",
+            "semantic"
+          ],
+          "default": "semantic",
+          "description": "Defines in which manner import are sorted."
+        },
+        "typescriptHero.sort.semantic": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "plains",
+              "globals",
+              "locals"
+            ]
+          },
+          "maxItems": 3,
+          "minItems": 3,
+          "default": [
+            "plains",
+            "globals",
+            "locals"
+          ],
+          "description": "Defines sort order of imports when sort type is set to 'semantic'"
         }
       }
     }

--- a/src/common/config/ExtensionConfig.ts
+++ b/src/common/config/ExtensionConfig.ts
@@ -1,4 +1,5 @@
 import { ResolverConfig } from './ResolverConfig';
+import { SortConfig } from './SortConfig';
 
 /**
  * Configuration interface for TypeScript Hero
@@ -25,4 +26,13 @@ export interface ExtensionConfig {
      * @memberof ExtensionConfig
      */
     resolver: ResolverConfig;
+
+    /**
+     * Defines which sorting strategy will be applied
+     * 
+     * @readonly
+     * @type {SortConfig}
+     * @memberof ExtensionConfig
+     */
+    sort: SortConfig;
 }

--- a/src/common/config/SortConfig.ts
+++ b/src/common/config/SortConfig.ts
@@ -1,0 +1,28 @@
+/**
+ * Configuration interface for the imports sorting.
+ * 
+ * @interface SortConfig
+ */
+export interface SortConfig {
+    /**
+     * Defines sorting type.
+     * 
+     * @readonly
+     * @type {SortType}
+     * @memberof SortConfig
+     */
+    type: SortType;
+
+    /**
+     * Defines sort order when type is set to semantic
+     * 
+     * @readonly
+     * @type {ImportSemanticType[]}
+     * @memberof SortConfig
+     */
+    semantic: ImportSemanticType[];
+}
+
+export type SortType = 'ascending' | 'descending' | 'semantic';
+
+export type ImportSemanticType = 'plains' | 'globals' | 'locals';

--- a/src/common/config/index.ts
+++ b/src/common/config/index.ts
@@ -1,2 +1,3 @@
 export * from './ExtensionConfig';
 export * from './ResolverConfig';
+export * from './SortConfig';

--- a/src/extension/VscodeExtensionConfig.ts
+++ b/src/extension/VscodeExtensionConfig.ts
@@ -1,5 +1,5 @@
-import { ExtensionConfig, ResolverConfig } from '../common/config';
-import { ImportLocation, GenerationOptions } from '../common/ts-generation';
+import { ExtensionConfig, ImportSemanticType, ResolverConfig, SortConfig, SortType } from '../common/config';
+import { GenerationOptions, ImportLocation } from '../common/ts-generation';
 import { injectable } from 'inversify';
 import { workspace } from 'vscode';
 
@@ -15,6 +15,7 @@ const sectionKey = 'typescriptHero';
 @injectable()
 export class VscodeExtensionConfig implements ExtensionConfig {
     private resolverConfig: ResolverConfig = new VscodeResolverConfig();
+    private sortConfig: SortConfig = new VscodeSortConfig();
 
     /**
      * The actual log level.
@@ -36,6 +37,17 @@ export class VscodeExtensionConfig implements ExtensionConfig {
      */
     public get resolver(): ResolverConfig {
         return this.resolverConfig;
+    }
+
+    /**
+     * Defines which sorting strategy will be applied
+     * 
+     * @readonly
+     * @type {SortConfig}
+     * @memberof VscodeExntesionConfig
+     */
+    public get sort(): SortConfig {
+        return this.sortConfig;
     }
 }
 
@@ -152,5 +164,34 @@ class VscodeResolverConfig implements ResolverConfig {
             stringQuoteStyle: this.stringQuoteStyle,
             tabSize: this.tabSize,
         };
+    }
+}
+
+/**
+ * Configuration class for imports sorting.
+ * 
+ * @class VscodeSortConfig
+ */
+class VscodeSortConfig implements SortConfig {
+    /**
+     * Defines sorting type.
+     * 
+     * @readonly
+     * @type {SortType}
+     * @memberof VscodeSortConfig
+     */
+    public get type(): SortType {
+        return workspace.getConfiguration(sectionKey).get<SortType>('sort.type');
+    }
+
+    /**
+     * Defines sort order when type is set to semantic.
+     * 
+     * @readonly
+     * @type {SemanticType[]}
+     * @memberof VscodeSortConfig
+     */
+    public get semantic(): ImportSemanticType[] {
+        return workspace.getConfiguration(sectionKey).get<ImportSemanticType[]>('sort.semantic');
     }
 }

--- a/test/_workspace/extension/extensions/importResolveExtension/organizeImports.ts
+++ b/test/_workspace/extension/extensions/importResolveExtension/organizeImports.ts
@@ -1,8 +1,12 @@
 import { StructuralParentClass } from '../subfolderstructure';
 import { Class1, FancierLibraryClass, ExportAlias, MyClass } from '../resourceIndex';
 import 'foo-bar';
+import * as React from 'react';
+import { Input } from '@angular/core';
 
 let foo = new MyClass();
 let a = ExportAlias;
 let b = new FancierLibraryClass();
 let c = new StructuralParentClass();
+let r = React;
+let input = Input;


### PR DESCRIPTION
add ability to define imports order

- Closes #102 <nr>

#### Description
I've added setting typescriptHero.sort according to plan outlined in #102. So now with sorting enabled and `sort.type` set to `semantic` extension sort imports not only alphabetically, but by their semantic type as well