### PR TITLE
Removed code outline window when disabled per config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+#### Changed
+- The Code outline view is now hidden when disabled (`typescriptHero.codeOutline.enabled`) ([#236](https://github.com/buehler/typescript-hero/issues/236))
 #### Fixed
 - Some abstract methods were not implemented from interfaces
 - Optional parameters are implemented now ([#141](https://github.com/buehler/typescript-hero/issues/141))

--- a/package.json
+++ b/package.json
@@ -168,7 +168,8 @@
       "explorer": [
         {
           "id": "documentCodeOutline",
-          "name": "Code outline"
+          "name": "Code outline",
+          "when": "config.typescriptHero.codeOutline.enabled != false"
         }
       ]
     },


### PR DESCRIPTION
During the July release, VS Code learned how to hide custom views based on workspace configurations -
 this pull teaches Typescript Hero how to use this trick too.