### PR TITLE
fix(imports): ignore imports to remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The following settings do have the prefix `resolver`. So an example setting coul
 | multiLineTrailingComma                | When multiline imports are created, `true` inserts a trailing comma to the last line |
 | disableImportSorting                  | Disable sorting during organize imports action                                       |
 | importGroups                          | The groups that are used for sorting the imports (description below)                 |
+| ignoreImportsForOrganize              | Imports that are never removed during organize import (e.g. react)                   |
 
 ### Code outline view
 

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "build": "del-cli ./out && tsc -p ./config/tsconfig.build.json",
     "package": "npm run build && del-cli './*.vsix' && vsce package",
     "semantic-release-pre": "semantic-release pre",
-    "semantic-release": "vsce package && vsce publish -p $VSCE_TOKEN && npm install && semantic-release post"
+    "semantic-release": "npm run semantic-release-pre && vsce package && vsce publish -p $VSCE_TOKEN && npm install && semantic-release post"
   },
   "devDependencies": {
     "@types/chai": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -247,6 +247,17 @@
           "default": false,
           "description": "Defines if sorting is disable during organize imports."
         },
+        "typescriptHero.resolver.ignoreImportsForOrganize": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "default": [
+            "react"
+          ],
+          "description": "Defines imports (libraries, so the 'from' part), which are not removed during 'organize imports'."
+        },
         "typescriptHero.resolver.importGroups": {
           "type": "array",
           "items": {

--- a/src/common/config/ResolverConfig.ts
+++ b/src/common/config/ResolverConfig.ts
@@ -89,6 +89,14 @@ export interface ResolverConfig {
     disableImportSorting: boolean;
 
     /**
+     * List of import libraries ("from" part) which are ignored during the organize import function.
+     * 
+     * @type {string[]}
+     * @memberof ResolverConfig
+     */
+    ignoreImportsForOrganize: string[];
+
+    /**
      * Returns the configured import groups. On a parsing error, a default should be provided.
      * 
      * @type {ImportGroup[]}

--- a/src/extension/VscodeExtensionConfig.ts
+++ b/src/extension/VscodeExtensionConfig.ts
@@ -173,7 +173,7 @@ class VscodeResolverConfig implements ResolverConfig {
      * @memberof VscodeResolverConfig
      */
     public get ignoreImportsForOrganize(): string[] {
-        return workspace.getConfiguration().get<string[]>('resolver.ignoreImportsForOrganize') || [];
+        return workspace.getConfiguration(sectionKey).get<string[]>('resolver.ignoreImportsForOrganize') || [];
     }
 
     /**

--- a/src/extension/VscodeExtensionConfig.ts
+++ b/src/extension/VscodeExtensionConfig.ts
@@ -166,6 +166,17 @@ class VscodeResolverConfig implements ResolverConfig {
     }
 
     /**
+     * Returns the list of imports that should be ignored during organize import feature.
+     * 
+     * @readonly
+     * @type {string[]}
+     * @memberof VscodeResolverConfig
+     */
+    public get ignoreImportsForOrganize(): string[] {
+        return workspace.getConfiguration().get<string[]>('resolver.ignoreImportsForOrganize') || [];
+    }
+
+    /**
      * Returns the configured import groups. On a parsing error, the default is used.
      * 
      * @type {ImportGroup[]}

--- a/src/extension/managers/ImportManager.ts
+++ b/src/extension/managers/ImportManager.ts
@@ -212,6 +212,10 @@ export class ImportManager implements ObjectManager {
         let keep: Import[] = [];
 
         for (const actImport of this.imports) {
+            if (ImportManager.config.resolver.ignoreImportsForOrganize.indexOf(actImport.libraryName) >= 0) {
+                keep.push(actImport);
+                continue;
+            }
             if (actImport instanceof NamespaceImport ||
                 actImport instanceof ExternalModuleImport) {
                 if (this._parsedDocument.nonLocalUsages.indexOf(actImport.alias) > -1) {

--- a/test/_workspace/extension/managers/ImportManagerFile.tsx
+++ b/test/_workspace/extension/managers/ImportManagerFile.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+export function doSomething(): any {
+    return (
+        <div></div>
+    );
+}

--- a/test/extension/extensions/CodeActionExtension.test.ts
+++ b/test/extension/extensions/CodeActionExtension.test.ts
@@ -25,10 +25,11 @@ class SpyCodeAction implements CodeAction {
     }
 }
 
+const rootPath = Container.get<string>(iocSymbols.rootPath);
+
 describe('CodeActionExtension', () => {
 
     let extension: any;
-    const rootPath = Container.get<string>(iocSymbols.rootPath);
 
     before(async () => {
         const ctx = Container.get<ExtensionContext>(iocSymbols.extensionContext);

--- a/test/extension/extensions/CodeCompletionExtension.test.ts
+++ b/test/extension/extensions/CodeCompletionExtension.test.ts
@@ -79,25 +79,20 @@ describe('CodeCompletionExtension', () => {
         result![0].detail!.should.equal('/server/indices/MyClass');
     });
 
-    it('shoud add an insert text edit if import would be new', async () => {
+    it('shoud add an insert command text edit if import would be new', async () => {
         const result = await extension.provideCompletionItems(document, new vscode.Position(6, 5), token);
 
         should.exist(result);
-        result![0].additionalTextEdits!.should.be.an('array').with.lengthOf(1);
-        result![0].additionalTextEdits![0].newText.should.equal(
-            `import { MyClass } from '../../../server/indices/MyClass';\n` +
-            `import { AlreadyImported } from './codeCompletionImports';\n`,
-        );
+        result![0].command!.command.should.equal('typescriptHero.codeCompletion.executeIntellisenseItem');
+        result![0].command!.arguments![1].declaration.name.should.equal('MyClass');
     });
 
-    it('shoud add a replace text edit if import will be updated with new specifier', async () => {
+    it('shoud add a replace command text edit if import will be updated with new specifier', async () => {
         const result = await extension.provideCompletionItems(document, new vscode.Position(9, 10), token);
 
         should.exist(result);
-        result![0].additionalTextEdits!.should.be.an('array').with.lengthOf(1);
-        result![0].additionalTextEdits![0].newText.should.equal(
-            `import { AlreadyImported, ShouldBeImported } from './codeCompletionImports';\n`,
-        );
+        result![0].command!.command.should.equal('typescriptHero.codeCompletion.executeIntellisenseItem');
+        result![0].command!.arguments![1].declaration.name.should.equal('ShouldBeImported');
     });
 
     it('shoud resolve to no import if import is already imported', async () => {

--- a/test/extension/extensions/CodeCompletionExtension.test.ts
+++ b/test/extension/extensions/CodeCompletionExtension.test.ts
@@ -10,6 +10,8 @@ import { iocSymbols } from '../../../src/extension/IoCSymbols';
 
 const should = chai.should();
 
+const rootPath = Container.get<string>(iocSymbols.rootPath);
+
 describe('CodeCompletionExtension', () => {
 
     const token = new vscode.CancellationTokenSource().token;
@@ -17,8 +19,6 @@ describe('CodeCompletionExtension', () => {
     let extension: CodeCompletionExtension;
 
     before(async () => {
-        const rootPath = Container.get<string>(iocSymbols.rootPath);
-
         const file = join(
             rootPath,
             'extension/extensions/codeCompletionExtension/codeCompletionFile.ts',

--- a/test/extension/extensions/DocumentSymbolStructureExtension.test.ts
+++ b/test/extension/extensions/DocumentSymbolStructureExtension.test.ts
@@ -19,13 +19,14 @@ import {
     NotParseableStructureTreeItem,
 } from '../../../src/extension/provider-items/document-structure/NotParseableStructureTreeItem';
 
+const rootPath = Container.get<string>(iocSymbols.rootPath);
+
 describe('DocumentSymbolStructureExtension', () => {
 
     let extension: DocumentSymbolStructureExtension;
     let document: vscode.TextDocument;
 
     before(async () => {
-        const rootPath = Container.get<string>(iocSymbols.rootPath);
         const file = join(
             rootPath,
             'extension/extensions/documentSymbolStructureExtension/documentSymbolFile.ts',

--- a/test/extension/extensions/ImportResolveExtension.test.ts
+++ b/test/extension/extensions/ImportResolveExtension.test.ts
@@ -11,13 +11,13 @@ import { iocSymbols } from '../../../src/extension/IoCSymbols';
 
 chai.should();
 
+const rootPath = Container.get<string>(iocSymbols.rootPath);
+
 describe('ImportResolveExtension', () => {
 
-    let rootPath: string;
     let extension: any;
 
     before(async () => {
-        rootPath = Container.get<string>(iocSymbols.rootPath);
         const file = join(
             rootPath,
             'extension/extensions/importResolveExtension/addImportToDocument.ts',
@@ -57,7 +57,6 @@ describe('ImportResolveExtension', () => {
     });
 
     describe('addImportToDocument', () => {
-        const rootPath = Container.get<string>(iocSymbols.rootPath);
         const file = join(
             rootPath,
             'extension/extensions/importResolveExtension/addImportToDocument.ts',

--- a/test/extension/import-grouping/KeywordImportGroup.test.ts
+++ b/test/extension/import-grouping/KeywordImportGroup.test.ts
@@ -10,6 +10,8 @@ import { iocSymbols } from '../../../src/extension/IoCSymbols';
 
 chai.should();
 
+const rootPath = Container.get<string>(iocSymbols.rootPath);
+
 describe('KeywordImportGroup', () => {
 
     let file: File;
@@ -18,7 +20,6 @@ describe('KeywordImportGroup', () => {
     let generator: TypescriptCodeGenerator;
 
     before(async () => {
-        const rootPath = Container.get<string>(iocSymbols.rootPath);
         const parser = Container.get<TypescriptParser>(iocSymbols.typescriptParser);
         config = Container.get<ExtensionConfig>(iocSymbols.configuration);
         generator = Container.get<TypescriptCodeGeneratorFactory>(iocSymbols.generatorFactory)();

--- a/test/extension/import-grouping/RegexImportGroup.test.ts
+++ b/test/extension/import-grouping/RegexImportGroup.test.ts
@@ -10,6 +10,8 @@ import { iocSymbols } from '../../../src/extension/IoCSymbols';
 
 chai.should();
 
+const rootPath = Container.get<string>(iocSymbols.rootPath);
+
 describe('RegexImportGroup', () => {
 
     let file: File;
@@ -19,7 +21,6 @@ describe('RegexImportGroup', () => {
 
     before(async () => {
         const parser = Container.get<TypescriptParser>(iocSymbols.typescriptParser);
-        const rootPath = Container.get<string>(iocSymbols.rootPath);
         config = Container.get<ExtensionConfig>(iocSymbols.configuration);
         generator = Container.get<TypescriptCodeGeneratorFactory>(iocSymbols.generatorFactory)();
         file = await parser.parseFile(

--- a/test/extension/import-grouping/RemainImportGroup.test.ts
+++ b/test/extension/import-grouping/RemainImportGroup.test.ts
@@ -10,6 +10,8 @@ import { iocSymbols } from '../../../src/extension/IoCSymbols';
 
 chai.should();
 
+const rootPath = Container.get<string>(iocSymbols.rootPath);
+
 describe('RemainImportGroup', () => {
 
     let file: File;
@@ -19,7 +21,6 @@ describe('RemainImportGroup', () => {
 
     before(async () => {
         const parser = Container.get<TypescriptParser>(iocSymbols.typescriptParser);
-        const rootPath = Container.get<string>(iocSymbols.rootPath);
         config = Container.get<ExtensionConfig>(iocSymbols.configuration);
         generator = Container.get<TypescriptCodeGeneratorFactory>(iocSymbols.generatorFactory)();
         file = await parser.parseFile(

--- a/test/extension/managers/ClassManager.test.ts
+++ b/test/extension/managers/ClassManager.test.ts
@@ -19,9 +19,10 @@ import { VscodeExtensionConfig } from '../../../src/extension/VscodeExtensionCon
 const should = chai.should();
 chai.use(sinonChai);
 
+const rootPath = Container.get<string>(iocSymbols.rootPath);
+
 describe('ClassManager', () => {
 
-    const rootPath = Container.get<string>(iocSymbols.rootPath);
     const file = join(rootPath, 'extension/managers/ClassManagerFile.ts');
     let document: TextDocument;
     let documentText: string;

--- a/test/extension/managers/ImportManager.test.ts
+++ b/test/extension/managers/ImportManager.test.ts
@@ -545,6 +545,33 @@ describe('ImportManager', () => {
             (ctrl as any).imports.should.have.lengthOf(1);
         });
 
+        describe('with .tsx files', () => {
+
+            const tsxFile = join(rootPath, 'extension/managers/ImportManagerFile.tsx');
+            let tsxDocument: TextDocument;
+            let tsxDocumentText: string;
+
+            before(async () => {
+                tsxDocument = await workspace.openTextDocument(tsxFile);
+                await window.showTextDocument(tsxDocument);
+
+                tsxDocumentText = tsxDocument.getText();
+            });
+
+            after(async () => {
+                await window.showTextDocument(document);
+            });
+
+            it('should not remove "react" since it is ignored in config', async () => {
+                const ctrl = await ImportManager.create(tsxDocument);
+                ctrl.organizeImports();
+
+                (ctrl as any).imports.should.have.lengthOf(1);
+                (ctrl as any).imports[0].libraryName.should.equal('react');
+            });
+
+        });
+
     });
 
     describe('commit()', () => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,7 +1,9 @@
 import 'reflect-metadata';
+
+import { ExtensionContext, Memento } from 'vscode';
+
 import { Container } from '../src/extension/IoC';
 import { iocSymbols } from '../src/extension/IoCSymbols';
-import { ExtensionContext, Memento } from 'vscode';
 
 // tslint:disable
 


### PR DESCRIPTION
- Fixes #250

#### Description

Adds a config setting to add some imports that are never removed (current default `react`)