### PR TITLE
fix(code-generation): Imports with no specifiers are generated correctly

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -26,7 +26,7 @@ function extendGenerator(generator: TypescriptCodeGenerator): void {
     GENERATORS[RegexImportGroup.name] = simpleGenerator;
     GENERATORS[RemainImportGroup.name] = simpleGenerator;
     GENERATORS[ImportProxy.name] = (proxy: ImportProxy) => {
-        if (proxy.specifiers.length <= 0) {
+        if (proxy.specifiers.length <= 0 && (proxy.defaultAlias || proxy.defaultPurposal)) {
             return generator.generate(
                 new DefaultImport(
                     proxy.libraryName, (proxy.defaultAlias || proxy.defaultPurposal)!, proxy.start, proxy.end,

--- a/test/extension/proxy-objects/ImportProxy.test.ts
+++ b/test/extension/proxy-objects/ImportProxy.test.ts
@@ -184,7 +184,7 @@ describe('ImportProxy', () => {
 
         before(() => {
             GENERATORS[ImportProxy.name] = (proxy: ImportProxy) => {
-                if (proxy.specifiers.length <= 0) {
+                if (proxy.specifiers.length <= 0 && (proxy.defaultAlias || proxy.defaultPurposal)) {
                     return generator.generate(
                         new DefaultImport(
                             proxy.libraryName, (proxy.defaultAlias || proxy.defaultPurposal)!, proxy.start, proxy.end,
@@ -236,6 +236,10 @@ describe('ImportProxy', () => {
             generator = new TypescriptCodeGenerator(optionsClone);
             proxy.defaultAlias = 'ALIAS';
             generator.generate(proxy).should.equal(`import ALIAS from 'foo'`);
+        });
+
+        it('should generate an empty named import if no specifiers and no default is set', () => {
+            generator.generate(proxy).should.equal(`import { } from 'foo';`);
         });
 
     });


### PR DESCRIPTION
- Fixes #258 

#### Description

Checks if an import proxy has a default purposal. If not, a named import is generated.

-> update of parser was necessary to "nicely" generate the import