### PR TITLE
feat(imports): Add organize on save via workspace hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ TypeScript Hero can manage your imports. It is capable of:
 - Import all missing identifiers of the current file
 - Remove unused imports and sort the remaining ones by alphabet
 - Do organize the imports when a document is saved
+  - Note that this feature is only enabled if the vscode setting `editor.formatOnSave` is enabled as well!
 
 #### Import groups
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The following settings do have the prefix `resolver`. So an example setting coul
 | importGroups                          | The groups that are used for sorting the imports (description below)                 |
 | ignoreImportsForOrganize              | Imports that are never removed during organize import (e.g. react)                   |
 | resolverMode                          | Which files should be considered to index for TypeScript Hero                        |
+| organizeOnSave                        | Enable or disable the `organizeImports` action on a save of a document               |
 
 ### Code outline view
 
@@ -109,6 +110,7 @@ TypeScript Hero can manage your imports. It is capable of:
 - Import something that is beneath your current cursor position (and ask you if it's not sure which one)
 - Import all missing identifiers of the current file
 - Remove unused imports and sort the remaining ones by alphabet
+- Do organize the imports when a document is saved
 
 #### Import groups
 

--- a/package.json
+++ b/package.json
@@ -257,6 +257,11 @@
           "default": false,
           "description": "Defines if sorting is disable during organize imports."
         },
+        "typescriptHero.resolver.organizeOnSave": {
+          "type": "boolean",
+          "default": true,
+          "description": "Defines if the imports should be organized on save."
+        },
         "typescriptHero.resolver.ignoreImportsForOrganize": {
           "type": "array",
           "items": {

--- a/src/common/config/ResolverConfig.ts
+++ b/src/common/config/ResolverConfig.ts
@@ -146,4 +146,13 @@ export interface ResolverConfig {
      * @memberof ResolverConfig
      */
     resolverModeLanguages: string[];
+
+    /**
+     * Defines if typescript hero tries to organize your imports of a
+     * file as soon as the file would be saved.
+     * 
+     * @type {boolean}
+     * @memberof ResolverConfig
+     */
+    organizeOnSave: boolean;
 }

--- a/src/extension/IoC.ts
+++ b/src/extension/IoC.ts
@@ -11,6 +11,7 @@ import { CodeActionExtension } from './extensions/CodeActionExtension';
 import { CodeCompletionExtension } from './extensions/CodeCompletionExtension';
 import { DocumentSymbolStructureExtension } from './extensions/DocumentSymbolStructureExtension';
 import { ImportResolveExtension } from './extensions/ImportResolveExtension';
+import { OrganizeImportsOnSaveExtension } from './extensions/OrganizeImportsOnSaveExtension';
 import { iocSymbols } from './IoCSymbols';
 import { TypeScriptHero } from './TypeScriptHero';
 import { VscodeLogger } from './utilities/VscodeLogger';
@@ -50,6 +51,7 @@ container.bind<BaseExtension>(iocSymbols.extensions).to(ImportResolveExtension).
 container.bind<BaseExtension>(iocSymbols.extensions).to(CodeCompletionExtension).inSingletonScope();
 container.bind<BaseExtension>(iocSymbols.extensions).to(DocumentSymbolStructureExtension).inSingletonScope();
 container.bind<BaseExtension>(iocSymbols.extensions).to(CodeActionExtension).inSingletonScope();
+container.bind<BaseExtension>(iocSymbols.extensions).to(OrganizeImportsOnSaveExtension).inSingletonScope();
 
 // Logging
 container

--- a/src/extension/VscodeExtensionConfig.ts
+++ b/src/extension/VscodeExtensionConfig.ts
@@ -12,7 +12,7 @@ const sectionKey = 'typescriptHero';
 /**
  * Configuration class for TypeScript Hero
  * Contains all exposed config endpoints.
- * 
+ *
  * @export
  * @class VscodeExtensionConfig
  */
@@ -27,7 +27,7 @@ export class VscodeExtensionConfig implements ExtensionConfig {
 
     /**
      * The actual log level.
-     * 
+     *
      * @readonly
      * @type {string}
      * @memberof VscodeExtensionConfig
@@ -38,7 +38,7 @@ export class VscodeExtensionConfig implements ExtensionConfig {
 
     /**
      * Configuration object for the resolver extension.
-     * 
+     *
      * @readonly
      * @type {ResolverConfig}
      * @memberof VscodeExtensionConfig
@@ -49,7 +49,7 @@ export class VscodeExtensionConfig implements ExtensionConfig {
 
     /**
      * Configuration object for the code outline extension.
-     * 
+     *
      * @readonly
      * @type {CodeOutlineConfig}
      * @memberof VscodeExtensionConfig
@@ -72,7 +72,7 @@ export class VscodeExtensionConfig implements ExtensionConfig {
 
 /**
  * Configuration class for the resolver extension.
- * 
+ *
  * @class VscodeResolverConfig
  */
 class VscodeResolverConfig implements ResolverConfig {
@@ -83,7 +83,7 @@ class VscodeResolverConfig implements ResolverConfig {
     /**
      * Defines, if there should be a space between the brace and the import specifiers.
      * {Symbol} vs { Symbol }
-     * 
+     *
      * @readonly
      * @type {boolean}
      * @memberof VscodeResolverConfig
@@ -96,7 +96,7 @@ class VscodeResolverConfig implements ResolverConfig {
     /**
      * Defines, if there should be a semicolon at the end of a statement.
      * import Symbol from 'symbol' vs import Symbol from 'symbol';
-     * 
+     *
      * @readonly
      * @type {boolean}
      * @memberof VscodeResolverConfig
@@ -108,7 +108,7 @@ class VscodeResolverConfig implements ResolverConfig {
 
     /**
      * Defines the quote style (' or ").
-     * 
+     *
      * @readonly
      * @type {string}
      * @memberof VscodeResolverConfig
@@ -120,7 +120,7 @@ class VscodeResolverConfig implements ResolverConfig {
     /**
      * Array of string that are excluded from indexing (e.g. build, out, node_modules).
      * If those parts are found after the workspace path is striped away, the file is ignored.
-     * 
+     *
      * @readonly
      * @type {string[]}
      * @memberof VscodeResolverConfig
@@ -135,7 +135,7 @@ class VscodeResolverConfig implements ResolverConfig {
 
     /**
      * A length number after which the import is transformed into a multiline import.
-     * 
+     *
      * @readonly
      * @type {number}
      * @memberof VscodeResolverConfig
@@ -164,7 +164,7 @@ class VscodeResolverConfig implements ResolverConfig {
 
     /**
      * Defines, if sorting is obligatory during organize imports
-     * 
+     *
      * @readonly
      * @type {boolean}
      * @memberof ResolverConfig
@@ -176,7 +176,7 @@ class VscodeResolverConfig implements ResolverConfig {
 
     /**
      * Returns the tab size that is configured in vscode.
-     * 
+     *
      * @readonly
      * @type {number}
      * @memberof VscodeResolverConfig
@@ -187,7 +187,7 @@ class VscodeResolverConfig implements ResolverConfig {
 
     /**
      * Returns the list of imports that should be ignored during organize import feature.
-     * 
+     *
      * @readonly
      * @type {string[]}
      * @memberof VscodeResolverConfig
@@ -198,7 +198,7 @@ class VscodeResolverConfig implements ResolverConfig {
 
     /**
      * Returns the configured import groups. On a parsing error, the default is used.
-     * 
+     *
      * @type {ImportGroup[]}
      * @memberof VscodeResolverConfig
      */
@@ -224,7 +224,7 @@ class VscodeResolverConfig implements ResolverConfig {
 
     /**
      * All information that are needed to print an import.
-     * 
+     *
      * @readonly
      * @type {TypescriptGenerationOptions}
      * @memberof VscodeResolverConfig
@@ -242,7 +242,7 @@ class VscodeResolverConfig implements ResolverConfig {
 
     /**
      * Current mode of the resolver.
-     * 
+     *
      * @readonly
      * @type {ResolverMode}
      * @memberof VscodeResolverConfig
@@ -260,7 +260,7 @@ class VscodeResolverConfig implements ResolverConfig {
      *
      * @example `ES6`
      * Will return: ['\*\*\/\*.js', '\*\*\/\*.jsx']
-     * 
+     *
      * @type {string[]}
      * @memberof VscodeResolverConfig
      */
@@ -286,7 +286,7 @@ class VscodeResolverConfig implements ResolverConfig {
      *
      * @example `TypeScript`
      * Will return: ['typescript', 'typescriptreact']
-     * 
+     *
      * @readonly
      * @type {string[]}
      * @memberof VscodeResolverConfig
@@ -311,20 +311,22 @@ class VscodeResolverConfig implements ResolverConfig {
     /**
      * Defines if typescript hero tries to organize your imports of a
      * file as soon as the file would be saved.
-     * 
+     * Is a combination between the editor.formatOnSave and the resolver settings.
+     *
      * @readonly
      * @type {boolean}
      * @memberof VscodeResolverConfig
      */
     public get organizeOnSave(): boolean {
-        const value = this.workspaceSection.get<boolean>('resolver.organizeOnSave');
-        return value !== undefined ? value : false;
+        const typescriptHeroValue = this.workspaceSection.get<boolean>('resolver.organizeOnSave', true);
+        const editorValue = workspace.getConfiguration().get('editor.formatOnSave', false);
+        return typescriptHeroValue && editorValue;
     }
 }
 
 /**
  * Configuration interface for the code outline feature.
- * 
+ *
  * @class VscodeCodeOutlineConfig
  * @implements {CodeOutlineConfig}
  */
@@ -335,7 +337,7 @@ class VscodeCodeOutlineConfig implements CodeOutlineConfig {
 
     /**
      * Defined if the code outline feature is enabled or not.
-     * 
+     *
      * @readonly
      * @type {boolean}
      * @memberof VscodeCodeOutlineConfig

--- a/src/extension/VscodeExtensionConfig.ts
+++ b/src/extension/VscodeExtensionConfig.ts
@@ -307,6 +307,19 @@ class VscodeResolverConfig implements ResolverConfig {
 
         return languages;
     }
+
+    /**
+     * Defines if typescript hero tries to organize your imports of a
+     * file as soon as the file would be saved.
+     * 
+     * @readonly
+     * @type {boolean}
+     * @memberof VscodeResolverConfig
+     */
+    public get organizeOnSave(): boolean {
+        const value = this.workspaceSection.get<boolean>('resolver.organizeOnSave');
+        return value !== undefined ? value : false;
+    }
 }
 
 /**

--- a/src/extension/extensions/OrganizeImportsOnSaveExtension.ts
+++ b/src/extension/extensions/OrganizeImportsOnSaveExtension.ts
@@ -9,7 +9,7 @@ import { BaseExtension } from './BaseExtension';
 
 /**
  * Extension that does sort and organize the imports as soon as a document will be saved.
- * 
+ *
  * @export
  * @class OrganizeImportsOnSaveExtension
  * @extends {BaseExtension}
@@ -29,7 +29,7 @@ export class OrganizeImportsOnSaveExtension extends BaseExtension {
 
     /**
      * Initialized the extension. Registers the commands and other disposables to the context.
-     * 
+     *
      * @memberof OrganizeImportsOnSaveExtension
      */
     public initialize(): void {
@@ -39,6 +39,7 @@ export class OrganizeImportsOnSaveExtension extends BaseExtension {
                 return;
             }
 
+            this.logger.info(`Organize on save for document "${event.document.fileName}".`);
             event.waitUntil(
                 ImportManager
                     .create(event.document)
@@ -51,7 +52,7 @@ export class OrganizeImportsOnSaveExtension extends BaseExtension {
 
     /**
      * Disposes the extension.
-     * 
+     *
      * @memberof OrganizeImportsOnSaveExtension
      */
     public dispose(): void {

--- a/src/extension/extensions/OrganizeImportsOnSaveExtension.ts
+++ b/src/extension/extensions/OrganizeImportsOnSaveExtension.ts
@@ -8,7 +8,7 @@ import { ImportManager } from '../managers';
 import { BaseExtension } from './BaseExtension';
 
 /**
- * 
+ * Extension that does sort and organize the imports as soon as a document will be saved.
  * 
  * @export
  * @class OrganizeImportsOnSaveExtension
@@ -40,7 +40,8 @@ export class OrganizeImportsOnSaveExtension extends BaseExtension {
             }
 
             event.waitUntil(
-                ImportManager.create(event.document)
+                ImportManager
+                    .create(event.document)
                     .then(manager => manager.organizeImports().calculateTextEdits()),
             );
         }));

--- a/src/extension/extensions/OrganizeImportsOnSaveExtension.ts
+++ b/src/extension/extensions/OrganizeImportsOnSaveExtension.ts
@@ -24,7 +24,7 @@ export class OrganizeImportsOnSaveExtension extends BaseExtension {
         @inject(iocSymbols.configuration) private config: ExtensionConfig,
     ) {
         super(context);
-        this.logger = loggerFactory('ImportResolveExtension');
+        this.logger = loggerFactory('OrganizeImportsOnSaveExtension');
     }
 
     /**

--- a/src/extension/extensions/OrganizeImportsOnSaveExtension.ts
+++ b/src/extension/extensions/OrganizeImportsOnSaveExtension.ts
@@ -1,0 +1,59 @@
+import { inject, injectable } from 'inversify';
+import { ExtensionContext, workspace } from 'vscode';
+
+import { ExtensionConfig } from '../../common/config';
+import { Logger, LoggerFactory } from '../../common/utilities';
+import { iocSymbols } from '../IoCSymbols';
+import { ImportManager } from '../managers';
+import { BaseExtension } from './BaseExtension';
+
+/**
+ * 
+ * 
+ * @export
+ * @class OrganizeImportsOnSaveExtension
+ * @extends {BaseExtension}
+ */
+@injectable()
+export class OrganizeImportsOnSaveExtension extends BaseExtension {
+    private logger: Logger;
+
+    constructor(
+        @inject(iocSymbols.extensionContext) context: ExtensionContext,
+        @inject(iocSymbols.loggerFactory) loggerFactory: LoggerFactory,
+        @inject(iocSymbols.configuration) private config: ExtensionConfig,
+    ) {
+        super(context);
+        this.logger = loggerFactory('ImportResolveExtension');
+    }
+
+    /**
+     * Initialized the extension. Registers the commands and other disposables to the context.
+     * 
+     * @memberof OrganizeImportsOnSaveExtension
+     */
+    public initialize(): void {
+        this.context.subscriptions.push(workspace.onWillSaveTextDocument((event) => {
+            if (!this.config.resolver.organizeOnSave) {
+                this.logger.info('Organize on save is deactivated through config.');
+                return;
+            }
+
+            event.waitUntil(
+                ImportManager.create(event.document)
+                    .then(manager => manager.organizeImports().calculateTextEdits()),
+            );
+        }));
+
+        this.logger.info('Initialized');
+    }
+
+    /**
+     * Disposes the extension.
+     * 
+     * @memberof OrganizeImportsOnSaveExtension
+     */
+    public dispose(): void {
+        this.logger.info('Disposed');
+    }
+}

--- a/test/_workspace/.vscode/settings.json
+++ b/test/_workspace/.vscode/settings.json
@@ -12,5 +12,6 @@
     "typescriptHero.verbosity": "Warnings",
     "tslint.enable": false,
     "typescriptHero.codeOutline.enabled": true,
-    "typescriptHero.resolver.organizeOnSave": false
+    "typescriptHero.resolver.organizeOnSave": false,
+    "editor.formatOnSave": true
 }

--- a/test/_workspace/.vscode/settings.json
+++ b/test/_workspace/.vscode/settings.json
@@ -11,6 +11,6 @@
     ],
     "typescriptHero.verbosity": "Warnings",
     "tslint.enable": false,
-    "typescript.check.tscVersion": false,
-    "typescriptHero.codeOutline.enabled": true
+    "typescriptHero.codeOutline.enabled": true,
+    "typescriptHero.resolver.organizeOnSave": false
 }

--- a/test/extension/extensions/OrganizeImportsOnSaveExtension.test.ts
+++ b/test/extension/extensions/OrganizeImportsOnSaveExtension.test.ts
@@ -1,0 +1,55 @@
+import * as chai from 'chai';
+import { join } from 'path';
+import { DeclarationIndex } from 'typescript-parser';
+import * as vscode from 'vscode';
+
+import { Container } from '../../../src/extension/IoC';
+import { iocSymbols } from '../../../src/extension/IoCSymbols';
+
+chai.should();
+
+const rootPath = Container.get<string>(iocSymbols.rootPath);
+
+describe('OrganizeImportsOnSaveExtension', () => {
+
+    let document: vscode.TextDocument;
+    let index: DeclarationIndex;
+
+    before(async () => {
+        const file = join(
+            rootPath,
+            'extension/extensions/organizeImportsOnSaveExtension/organizeFile.ts',
+        );
+        document = await vscode.workspace.openTextDocument(file);
+
+        await vscode.window.showTextDocument(document);
+
+        index = Container.get<DeclarationIndex>(iocSymbols.declarationIndex);
+        await index.buildIndex(
+            [
+                join(
+                    rootPath,
+                    'server/indices/MyClass.ts',
+                ),
+            ],
+        );
+    });
+
+    afterEach(async () => {
+        await vscode.window.activeTextEditor!.edit((builder) => {
+            builder.delete(new vscode.Range(
+                new vscode.Position(0, 0),
+                document.lineAt(document.lineCount - 1).rangeIncludingLineBreak.end,
+            ));
+        });
+    });
+
+    it('should remove an unused import on save', async () => {
+        console.log(document, index);
+    });
+
+    it('should not remove a used import on save');
+
+    it('should not remove something if not saved');
+
+});

--- a/test/extension/extensions/OrganizeImportsOnSaveExtension.test.ts
+++ b/test/extension/extensions/OrganizeImportsOnSaveExtension.test.ts
@@ -60,7 +60,7 @@ describe('OrganizeImportsOnSaveExtension', () => {
         await ctrl.commit();
 
         document.lineAt(0).text.should.equals(
-            `import { Class1 } from '../../../server/indices/MyClass';`,
+            `import { Class1 } from '../../../server/indices';`,
         );
 
         await document.save();

--- a/test/extension/extensions/OrganizeImportsOnSaveExtension.test.ts
+++ b/test/extension/extensions/OrganizeImportsOnSaveExtension.test.ts
@@ -60,7 +60,7 @@ describe('OrganizeImportsOnSaveExtension', () => {
         await ctrl.commit();
 
         document.lineAt(0).text.should.equals(
-            `import { Class1 } from '../../../server/indices';`,
+            `import { Class1 } from '../../../server/indices/MyClass';`,
         );
 
         await document.save();
@@ -76,7 +76,7 @@ describe('OrganizeImportsOnSaveExtension', () => {
         await ctrl.commit();
 
         document.lineAt(0).text.should.equals(
-            `import { Class1, Class2 } from '../../../server/indices';`,
+            `import { Class1, Class2 } from '../../../server/indices/MyClass';`,
         );
 
         await vscode.window.activeTextEditor!.edit((builder) => {
@@ -89,7 +89,7 @@ describe('OrganizeImportsOnSaveExtension', () => {
         await document.save();
 
         document.lineAt(0).text.should.equals(
-            `import { Class2 } from '../../../server/indices';`,
+            `import { Class2 } from '../../../server/indices/MyClass';`,
         );
     });
 


### PR DESCRIPTION
- Closes #150

#### Description

Add an extension part that hooks into the `onWillSaveDocument` hook of vscode
to enable organize on save feature.