### PR TITLE
fix: disable organize command when not in a code file

### DIFF
--- a/src/extension/extensions/OrganizeImportsOnSaveExtension.ts
+++ b/src/extension/extensions/OrganizeImportsOnSaveExtension.ts
@@ -16,6 +16,12 @@ import { BaseExtension } from './BaseExtension';
  */
 @injectable()
 export class OrganizeImportsOnSaveExtension extends BaseExtension {
+    private compatibleLanguages: string[] = [
+        'typescript',
+        'typescriptreact',
+        'javascript',
+        'javascriptreact',
+    ];
     private logger: Logger;
 
     constructor(
@@ -36,6 +42,10 @@ export class OrganizeImportsOnSaveExtension extends BaseExtension {
         this.context.subscriptions.push(workspace.onWillSaveTextDocument((event) => {
             if (!this.config.resolver.organizeOnSave) {
                 this.logger.info('Organize on save is deactivated through config.');
+                return;
+            }
+            if (this.compatibleLanguages.indexOf(event.document.languageId) <= 0) {
+                this.logger.info(`Organize imports for languageId "${event.document.languageId}" not possible.`);
                 return;
             }
 

--- a/src/extension/extensions/OrganizeImportsOnSaveExtension.ts
+++ b/src/extension/extensions/OrganizeImportsOnSaveExtension.ts
@@ -44,7 +44,7 @@ export class OrganizeImportsOnSaveExtension extends BaseExtension {
                 this.logger.info('Organize on save is deactivated through config.');
                 return;
             }
-            if (this.compatibleLanguages.indexOf(event.document.languageId) <= 0) {
+            if (this.compatibleLanguages.indexOf(event.document.languageId) < 0) {
                 this.logger.info(`Organize imports for languageId "${event.document.languageId}" not possible.`);
                 return;
             }

--- a/test/extension/extensions/DocumentSymbolStructureExtension.test.ts
+++ b/test/extension/extensions/DocumentSymbolStructureExtension.test.ts
@@ -42,17 +42,6 @@ describe('DocumentSymbolStructureExtension', () => {
         extension = new DocumentSymbolStructureExtension(ctx, logger, config, parser);
     });
 
-    it('should return an empty array if no active window is set', async () => {
-        try {
-            await vscode.commands.executeCommand('workbench.action.closeAllEditors');
-
-            const elements = await extension.getChildren() as BaseStructureTreeItem[];
-            elements.should.have.lengthOf(0);
-        } finally {
-            await vscode.window.showTextDocument(document);
-        }
-    });
-
     it('should return a "file not parsable" if it is no ts file', async () => {
         const rootPath = Container.get<string>(iocSymbols.rootPath);
         const file = join(


### PR DESCRIPTION
<list of issues that are closed feature or fixed bug>

- Fixes #293 

#### Description

Check the language ID before executing the commands.