### PR TITLE
fix(parser): Fixating the typescript version to 2.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,8 +113,8 @@
     "inversify-inject-decorators": "^3.0.1",
     "reflect-metadata": "^0.1.10",
     "tslib": "^1.7.1",
-    "typescript": "^2.5.2",
-    "typescript-parser": "^1.3.1"
+    "typescript": "~2.4.2",
+    "typescript-parser": "^1.3.3"
   },
   "activationEvents": [
     "onLanguage:typescript",

--- a/src/extension/extensions/DocumentSymbolStructureExtension.ts
+++ b/src/extension/extensions/DocumentSymbolStructureExtension.ts
@@ -26,7 +26,7 @@ import { BaseExtension } from './BaseExtension';
 
 /**
  * Extension that provides code completion for typescript files. Uses the calculated index to provide information.
- * 
+ *
  * @export
  * @class DocumentSymbolStructureExtension
  * @extends {BaseExtension}
@@ -53,7 +53,7 @@ export class DocumentSymbolStructureExtension extends BaseExtension implements T
 
     /**
      * Initialized the extension. Registers the commands and other disposables to the context.
-     * 
+     *
      * @memberof DocumentSymbolStructureExtension
      */
     public initialize(): void {
@@ -73,7 +73,7 @@ export class DocumentSymbolStructureExtension extends BaseExtension implements T
 
     /**
      * Disposes the extension.
-     * 
+     *
      * @memberof DocumentSymbolStructureExtension
      */
     public dispose(): void {
@@ -100,7 +100,12 @@ export class DocumentSymbolStructureExtension extends BaseExtension implements T
         }
 
         if (!this.documentCache) {
-            this.documentCache = await this.parser.parseSource(window.activeTextEditor.document.getText());
+            try {
+                this.documentCache = await this.parser.parseSource(window.activeTextEditor.document.getText());
+            } catch (e) {
+                this.logger.error('Document could not be parsed.', e);
+                return [];
+            }
         }
 
         if (!element) {
@@ -117,11 +122,11 @@ export class DocumentSymbolStructureExtension extends BaseExtension implements T
 
     /**
      * Takes a node (or undefined) and jumps to the nodes location. If undefined is passed, a warning message is displayed.
-     * 
+     *
      * @private
-     * @param {(Node | undefined)} node 
-     * @returns {Promise<void>} 
-     * 
+     * @param {(Node | undefined)} node
+     * @returns {Promise<void>}
+     *
      * @memberof DocumentSymbolStructureExtension
      */
     private async jumpToNode(node: Node | undefined): Promise<void> {
@@ -142,9 +147,9 @@ export class DocumentSymbolStructureExtension extends BaseExtension implements T
 
     /**
      * Method that recalculates the current document when the active window changed.
-     * 
+     *
      * @private
-     * 
+     *
      * @memberof DocumentSymbolStructureExtension
      */
     private activeWindowChanged(): void {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3209,18 +3209,18 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript-parser@^1.3.1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/typescript-parser/-/typescript-parser-1.3.2.tgz#66873e398f314a65d9cb8c69d4ef62b1b0ffbc72"
+typescript-parser@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/typescript-parser/-/typescript-parser-1.3.3.tgz#7535082b89553b1e2a298292a953d4c6f6fd069f"
   dependencies:
     coveralls "^2.13.1"
     lodash "^4.17.4"
     tslib "^1.7.1"
-    typescript "^2.4.1"
+    typescript "2.4.2"
 
-typescript@^2.4.1, typescript@^2.5.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.2.tgz#038a95f7d9bbb420b1bf35ba31d4c5c1dd3ffe34"
+typescript@2.4.2, typescript@~2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.2.tgz#f8395f85d459276067c988aa41837a8f82870844"
 
 uglify-js@1.x:
   version "1.3.5"


### PR DESCRIPTION
- Fixes #292

#### Description

Fixes the typescript version to 2.4.2 (`~2.4.2`) since 2.5.x has a bug with parsing.