### PR TITLE
Allow regex groups *after* keyword groups

### DIFF
--- a/src/extension/managers/ImportManager.ts
+++ b/src/extension/managers/ImportManager.ts
@@ -29,7 +29,7 @@ import { importRange } from '../helpers';
 import { ImportGroup } from '../import-grouping';
 import { Container } from '../IoC';
 import { iocSymbols } from '../IoCSymbols';
-import { importSort, specifierSort } from '../utilities/utilityFunctions';
+import { importGroupSortForPrecedence, importSort, specifierSort } from '../utilities/utilityFunctions';
 import { Logger } from '../utilities/winstonLogger';
 import { ObjectManager } from './ObjectManager';
 
@@ -409,8 +409,9 @@ export class ImportManager implements ObjectManager {
      * @memberof ImportManager
      */
     private addImportsToGroups(imports: Import[]): void {
+        const importGroupsWithPrecedence = importGroupSortForPrecedence(this.importGroups)
         for (const tsImport of imports) {
-            for (const group of this.importGroups) {
+            for (const group of importGroupsWithPrecedence) {
                 if (group.processImport(tsImport)) {
                     break;
                 }

--- a/src/extension/managers/ImportManager.ts
+++ b/src/extension/managers/ImportManager.ts
@@ -409,7 +409,7 @@ export class ImportManager implements ObjectManager {
      * @memberof ImportManager
      */
     private addImportsToGroups(imports: Import[]): void {
-        const importGroupsWithPrecedence = importGroupSortForPrecedence(this.importGroups)
+        const importGroupsWithPrecedence = importGroupSortForPrecedence(this.importGroups);
         for (const tsImport of imports) {
             for (const group of importGroupsWithPrecedence) {
                 if (group.processImport(tsImport)) {

--- a/src/extension/utilities/utilityFunctions.ts
+++ b/src/extension/utilities/utilityFunctions.ts
@@ -1,3 +1,4 @@
+import { ImportGroup, RegexImportGroup } from '../import-grouping';
 import {
     ClassDeclaration,
     ConstructorDeclaration,
@@ -39,6 +40,24 @@ export function stringSort(strA: string, strB: string, order: 'asc' | 'desc' = '
         result *= -1;
     }
     return result;
+}
+
+/**
+ * Orders import groups by matching precedence (regex first).  This is used internally by
+ * `ImportManager` when assigning imports to groups, so regex groups can appear later than
+ * keyword groups yet capture relevant imports nonetheless.
+ *
+ * @export
+ * @param {ImportGroup[]} importGroups The original import groups (as per extension configuration)
+ * @returns {ImportGroup[]} The same list, with Regex import groups appearing first.
+ */
+export function importGroupSortForPrecedence(importGroups: ImportGroup[]): ImportGroup[] {
+    const regexGroups: ImportGroup[] = []
+    const otherGroups: ImportGroup[] = []
+    for (const ig of importGroups) {
+        (ig instanceof RegexImportGroup ? regexGroups : otherGroups).push(ig)
+    }
+    return regexGroups.concat(otherGroups)
 }
 
 /**

--- a/src/extension/utilities/utilityFunctions.ts
+++ b/src/extension/utilities/utilityFunctions.ts
@@ -52,12 +52,12 @@ export function stringSort(strA: string, strB: string, order: 'asc' | 'desc' = '
  * @returns {ImportGroup[]} The same list, with Regex import groups appearing first.
  */
 export function importGroupSortForPrecedence(importGroups: ImportGroup[]): ImportGroup[] {
-    const regexGroups: ImportGroup[] = []
-    const otherGroups: ImportGroup[] = []
+    const regexGroups: ImportGroup[] = [];
+    const otherGroups: ImportGroup[] = [];
     for (const ig of importGroups) {
-        (ig instanceof RegexImportGroup ? regexGroups : otherGroups).push(ig)
+        (ig instanceof RegexImportGroup ? regexGroups : otherGroups).push(ig);
     }
-    return regexGroups.concat(otherGroups)
+    return regexGroups.concat(otherGroups);
 }
 
 /**

--- a/test/_workspace/.vscode/settings.json
+++ b/test/_workspace/.vscode/settings.json
@@ -9,6 +9,13 @@
         "dist",
         "resourceParser"
     ],
+    "typescriptHero.resolver.importGroups": [
+        "Plains",
+        "Modules",
+        "/cool-library/",
+        "/cooler-library/",
+        "Workspace"
+    ],
     "editor.tabSize": 4,
     "files.eol": "\n",
     "typescriptHero.verbosity": "warn",

--- a/test/_workspace/.vscode/settings.json
+++ b/test/_workspace/.vscode/settings.json
@@ -9,6 +9,7 @@
         "dist",
         "resourceParser"
     ],
+    "editor.tabSize": 4,
     "files.eol": "\n",
     "typescriptHero.verbosity": "warn",
     "tslint.enable": false,

--- a/test/single-workspace-tests/extension/managers/ImportManager.test.ts
+++ b/test/single-workspace-tests/extension/managers/ImportManager.test.ts
@@ -257,11 +257,13 @@ describe('ImportManager', () => {
             const ctrl = await ImportManager.create(document);
             const declaration = index.declarationInfos.find(o => o.declaration.name === 'NotBarelExported');
 
-            (ctrl as any).importGroups[2].imports.should.have.lengthOf(1);
+            // Import group 4 in single-workspace test settings is "Workspace"
+            (ctrl as any).importGroups[4].imports.should.have.lengthOf(1);
 
             ctrl.addDeclarationImport(declaration!);
 
-            (ctrl as any).importGroups[2].imports.should.have.lengthOf(2);
+            // Import group 4 in single-workspace test settings is "Workspace"
+            (ctrl as any).importGroups[4].imports.should.have.lengthOf(2);
         });
 
         it('should add an import to an existing import group', async () => {
@@ -269,11 +271,13 @@ describe('ImportManager', () => {
             const declaration = index.declarationInfos.find(o => o.declaration.name === 'Class2');
             const declaration2 = index.declarationInfos.find(o => o.declaration.name === 'Class3');
 
-            (ctrl as any).importGroups[2].imports.should.have.lengthOf(1);
+            // Import group 4 in single-workspace test settings is "Workspace"
+            (ctrl as any).importGroups[4].imports.should.have.lengthOf(1);
 
             ctrl.addDeclarationImport(declaration!).addDeclarationImport(declaration2!);
 
-            (ctrl as any).importGroups[2].imports.should.have.lengthOf(1);
+            // Import group 4 in single-workspace test settings is "Workspace"
+            (ctrl as any).importGroups[4].imports.should.have.lengthOf(1);
         });
 
     });

--- a/test/single-workspace-tests/extension/managers/ImportManager.test.ts
+++ b/test/single-workspace-tests/extension/managers/ImportManager.test.ts
@@ -348,11 +348,13 @@ describe('ImportManager', () => {
             const declaration = index.declarationInfos.find(o => o.declaration.name === 'myComponent');
             ctrl.addDeclarationImport(declaration!);
 
-            (ctrl as any).importGroups[2].imports.should.have.lengthOf(2);
+            // Import group 4 in single-workspace test settings is "Workspace"
+            (ctrl as any).importGroups[4].imports.should.have.lengthOf(2);
 
             ctrl.organizeImports();
 
-            (ctrl as any).importGroups[2].imports.should.have.lengthOf(1);
+            // Import group 4 in single-workspace test settings is "Workspace"
+            (ctrl as any).importGroups[4].imports.should.have.lengthOf(1);
         });
 
         it('should remove an unused specifier from an import', async () => {
@@ -541,6 +543,32 @@ describe('ImportManager', () => {
             (ctrl as any).imports.should.have.lengthOf(1);
             ctrl.organizeImports();
             (ctrl as any).imports.should.have.lengthOf(1);
+        });
+
+        it('should honor regex groups even if they appear later than keyword groups', async () => {
+            await window.activeTextEditor!.edit((builder) => {
+                builder.insert(
+                    new Position(0, 0),
+                    `
+                    import mainFx from 'some-regular-module'
+                    import { CoolerStuff, CoolerTitle } from 'cooler-library/items'
+                    import CoolLib from 'cool-library'
+                    import React, { Component } from 'react'
+
+                    import '../plain.ts'
+                    `.replace(/\n[ \t]+/g, '\n')
+                );
+                // Ensure imports are not stripped because they’re unused
+                builder.insert(
+                    new Position(12, 0),
+                    'console.log(mainFx, CoolerStuff, CoolerTitle, CoolLib, React, Component)\n'
+                )
+            });
+            const ctrl = await ImportManager.create(document);
+
+            await ctrl.organizeImports().commit();
+            const names = (ctrl as any).imports.map((l) => l.libraryName)
+            names.should.deep.equal(['../plain.ts', 'react', 'some-regular-module', 'cool-library', 'cooler-library/items', '../../server/indices'])
         });
 
     });

--- a/test/single-workspace-tests/extension/utilities/utilityFunctions.test.ts
+++ b/test/single-workspace-tests/extension/utilities/utilityFunctions.test.ts
@@ -1,0 +1,25 @@
+import * as chai from 'chai';
+chai.should();
+
+import { KeywordImportGroup, ImportGroupKeyword, RegexImportGroup } from '../../../../src/extension/import-grouping';
+import { importGroupSortForPrecedence } from '../../../../src/extension/utilities/utilityFunctions';
+
+describe('utilityFunctions', () => {
+  describe('importGroupSortForPrecedence', () => {
+    it('should prioritize regexes, leaving original order untouched besides that', () => {
+      const initialList = [
+        new KeywordImportGroup(ImportGroupKeyword.Modules),
+        new KeywordImportGroup(ImportGroupKeyword.Plains),
+        new RegexImportGroup("/cool-library/"),
+        new RegexImportGroup("/cooler-library/"),
+        new KeywordImportGroup(ImportGroupKeyword.Workspace),
+      ]
+      const expectedList = initialList.slice(2, 4)
+        .concat(initialList.slice(0, 2))
+        .concat(initialList.slice(4))
+
+      importGroupSortForPrecedence(initialList).should.deep.equal(expectedList,
+        'Regex Import Groups should appear first (and that should be the only change)')
+    });
+  });
+});


### PR DESCRIPTION
It was impossible to define regex groups when keyword groups were listed ahead of them and matching the same source. See #334 for details and examples. This addresses the issue.

- Fixes #334

#### Description

The code change itself is fairly minimal, adjusting the logic of `ImportManager#addImportsToGroups()` to rely on a new utility function. Both have added tests that pass.

#### A word about tests

Despite the badge saying `develop` passes build, it failed on my machine right from the forked code. I get a timeout and 4 undefined import declarations. I don't know enough about TS' internals to figure out why this was, so I left these failing tests as-is, and just added my (passing) ones. No previously-OK test broke in the process, obviously 😉 

Also, there was an implicit assumption by many tests that indent size was 4 (VSCode's default, and the original author's). But anyone running tests with a different User Setting would see a lot of failures. I fixed this by forcing a 4-space indent in the test workspace's settings.

#### VSCode, TypeScript and me…

This is the first time ever I write TypeScript for actual production code (I'm more an ES.Next kinda guy) or write VSCode extension stuff, so I'm sorry if some of my code, test or otherwise, seems non-idiomatic: feel free to point me in the right direction for you. I tried to abide the original coding style (had to disable my ESLint/Prettier settings to avoid unduly reformatting everything), I hope it's good with you!

I do intend to contribute two other PRs to this ext, though: one to address a personal need that I apparently share with many (e.g. #316): an option that lets us sort imports by first specifier name, not by module name. And another purely for "regex grooming": I know JS regexes (and regexes in general) intimately, and it seems to me a lot can be improved on the way they're used by the ext; because this is not feature-related and quite subjective, I'll make a separate PR out of it.

Looking forward to your feedback! (and explanations about why these other tests failed, I'm curious).

Best,