### PR TITLE
fix: Correctly ignore glob patterns from file search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ stages:
 notifications:
   email: false
 
+cache: yarn
+
 jobs:
   include:
     - stage: test
@@ -45,16 +47,6 @@ jobs:
         - yarn test --silent
       after_script:
         - greenkeeper-lockfile-upload
-    - stage: test
-      os: osx
-      sudo: false
-      env:
-        - CODE_TESTS_WORKSPACE=$TRAVIS_BUILD_DIR/test/_workspace
-        - CODE_TESTS_PATH=$TRAVIS_BUILD_DIR/out/test/single-workspace-tests
-      install:
-        - yarn install
-      script:
-        - yarn test --silent
     - stage: deploy
       env:
         - BUILD_LEADER_ID=3
@@ -77,3 +69,15 @@ jobs:
 
 # add as soon as multi root workspaces are available:
 #- CODE_TESTS_WORKSPACE=$TRAVIS_BUILD_DIR/test/multi-root.code-workspace CODE_TESTS_PATH=$TRAVIS_BUILD_DIR/out/test/multi-root-workspace-tests
+
+# OSX Build. which takes a billon years to complete.
+# - stage: test
+#   os: osx
+#   sudo: false
+#   env:
+#     - CODE_TESTS_WORKSPACE=$TRAVIS_BUILD_DIR/test/_workspace
+#     - CODE_TESTS_PATH=$TRAVIS_BUILD_DIR/out/test/single-workspace-tests
+#   install:
+#     - yarn install
+#   script:
+#     - yarn test --silent

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,6 +47,9 @@
                 "--extensionDevelopmentPath=${workspaceRoot}",
                 "--extensionTestsPath=${workspaceRoot}/out/test/single-workspace-tests/"
             ],
+            "env": {
+                "CI": "true"
+            },
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [
@@ -63,6 +66,9 @@
                 "--extensionDevelopmentPath=${workspaceRoot}",
                 "--extensionTestsPath=${workspaceRoot}/out/test/multi-root-workspace-tests/"
             ],
+            "env": {
+                "CI": "true"
+            },
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The following settings do have the prefix `codeCompletion`. So an example settin
 `typescriptHero.codeCompletion.completionSortOrder`.
 
 | Setting             | Description                                                                   |
-| ------------------- | ------------------------------------------------------------------------------|
+| ------------------- | ----------------------------------------------------------------------------- |
 | completionSortOrder | The order of import completions in suggestion list, `bottom` pushes them down |
 
 ### Import resolver

--- a/README.md
+++ b/README.md
@@ -90,22 +90,23 @@ The following settings do have the prefix `codeCompletion`. So an example settin
 The following settings do have the prefix `resolver`. So an example setting could be
 `typescriptHero.resolver.stringQuoteStyle`.
 
-| Setting                               | Description                                                                          |
-| ------------------------------------- | ------------------------------------------------------------------------------------ |
-| stringQuoteStyle                      | The string delimiter to use for the imports (`'` or `"`)                             |
-| ignorePatterns                        | If any of these strings is part of a file path, the file is ignored                  |
-| insertSpaceBeforeAndAfterImportBraces | If the extension should place spaces into import braces (`{Symbol}` vs `{ Symbol }`) |
-| insertSemicolons                      | If the extension should add a semicolon to the end of a statement                    |
-| multiLineWrapThreshold                | The threshold, when imports are converted into multiline imports                     |
-| multiLineTrailingComma                | When multiline imports are created, `true` inserts a trailing comma to the last line |
-| disableImportSorting                  | Disable sorting during organize imports action                                       |
-| disableImportRemovalOnOrganize        | Disable removal unsed imports during organize imports action                         |
-| importGroups                          | The groups that are used for sorting the imports (description below)                 |
-| ignoreImportsForOrganize              | Imports that are never removed during organize import (e.g. react)                   |
-| resolverMode                          | Which files should be considered to index for TypeScript Hero                        |
-| organizeOnSave                        | Enable or disable the `organizeImports` action on a save of a document               |
-| organizeSortsByFirstSpecifier         | When organizing runs, sort by first specifier/alias (if any) instead of module path  |
-| promptForSpecifiers                   | If the extension should ask the user for aliases and duplicate specifiers            |
+| Setting                               | Description                                                                                   |
+| ------------------------------------- | --------------------------------------------------------------------------------------------- |
+| stringQuoteStyle                      | The string delimiter to use for the imports (`'` or `"`)                                      |
+| workspaceIgnorePatterns               | If any of these strings is part of a file path, the file is ignored during workspace indexing |
+| moduleIgnorePatterns                  | If any of these strings is part of a file path, the file is ignored during module indexing    |
+| insertSpaceBeforeAndAfterImportBraces | If the extension should place spaces into import braces (`{Symbol}` vs `{ Symbol }`)          |
+| insertSemicolons                      | If the extension should add a semicolon to the end of a statement                             |
+| multiLineWrapThreshold                | The threshold, when imports are converted into multiline imports                              |
+| multiLineTrailingComma                | When multiline imports are created, `true` inserts a trailing comma to the last line          |
+| disableImportSorting                  | Disable sorting during organize imports action                                                |
+| disableImportRemovalOnOrganize        | Disable removal unsed imports during organize imports action                                  |
+| importGroups                          | The groups that are used for sorting the imports (description below)                          |
+| ignoreImportsForOrganize              | Imports that are never removed during organize import (e.g. react)                            |
+| resolverMode                          | Which files should be considered to index for TypeScript Hero                                 |
+| organizeOnSave                        | Enable or disable the `organizeImports` action on a save of a document                        |
+| organizeSortsByFirstSpecifier         | When organizing runs, sort by first specifier/alias (if any) instead of module path           |
+| promptForSpecifiers                   | If the extension should ask the user for aliases and duplicate specifiers                     |
 
 ### Code outline view
 

--- a/package.json
+++ b/package.json
@@ -215,9 +215,9 @@
           },
           "uniqueItems": true,
           "default": [
-            "**/build/**/*",
-            "**/out/**/*",
-            "**/dist/**/*"
+            "build/**/*",
+            "out/**/*",
+            "dist/**/*"
           ],
           "description": "Defines partial pathes (globs) that are ignored during indexing (e.g. 'node_modules/**/*' would exclude all modules).",
           "scope": "resource"

--- a/package.json
+++ b/package.json
@@ -221,11 +221,11 @@
           },
           "uniqueItems": true,
           "default": [
-            "build",
-            "out",
-            "dist"
+            "build/**/*",
+            "out/**/*",
+            "dist/**/*"
           ],
-          "description": "Defines partial pathes that are ignored during indexing (e.g. 'node_modules' would exclude all modules).",
+          "description": "Defines partial pathes (globs) that are ignored during indexing (e.g. 'node_modules/**/*' would exclude all modules).",
           "scope": "resource"
         },
         "typescriptHero.resolver.multiLineWrapThreshold": {

--- a/package.json
+++ b/package.json
@@ -215,9 +215,9 @@
           },
           "uniqueItems": true,
           "default": [
-            "build/**/*",
-            "out/**/*",
-            "dist/**/*"
+            "**/build/**/*",
+            "**/out/**/*",
+            "**/dist/**/*"
           ],
           "description": "Defines partial pathes (globs) that are ignored during indexing (e.g. 'node_modules/**/*' would exclude all modules).",
           "scope": "resource"

--- a/package.json
+++ b/package.json
@@ -208,18 +208,30 @@
           "description": "Defines if single or double quotes should be used.",
           "scope": "resource"
         },
-        "typescriptHero.resolver.ignorePatterns": {
+        "typescriptHero.resolver.workspaceIgnorePatterns": {
           "type": "array",
           "items": {
             "type": "string"
           },
           "uniqueItems": true,
           "default": [
-            "build/**/*",
-            "out/**/*",
-            "dist/**/*"
+            "**/build/**/*",
+            "**/out/**/*",
+            "**/dist/**/*"
           ],
-          "description": "Defines partial pathes (globs) that are ignored during indexing (e.g. 'node_modules/**/*' would exclude all modules).",
+          "description": "Defines partial pathes (globs) that are ignored during indexing of the **workspace** (e.g. 'node_modules/**/*' would exclude all modules).",
+          "scope": "resource"
+        },
+        "typescriptHero.resolver.moduleIgnorePatterns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "default": [
+            "**/node_modules/**/*"
+          ],
+          "description": "Defines partial pathes (globs) that are ignored during indexing of the **node_modules**. This patterns are attached to the node_module/<name> of each found module.",
           "scope": "resource"
         },
         "typescriptHero.resolver.multiLineWrapThreshold": {

--- a/src/common/config/ResolverConfig.ts
+++ b/src/common/config/ResolverConfig.ts
@@ -50,14 +50,26 @@ export interface ResolverConfig {
     stringQuoteStyle: string;
 
     /**
-     * Array of string that are excluded from indexing (e.g. build, out, node_modules).
-     * If those parts are found after the workspace path is striped away, the file is ignored.
+     * Array of string that are excluded from indexing of the workspace (e.g. build, out, dist).
+     * This patterns are ignored during indexing of the files found in the workspace.
+     * To exclude other files that are found in the node_modules, use moduleIgnorePatterns.
      *
      * @readonly
      * @type {string[]}
      * @memberof ResolverConfig
      */
-    ignorePatterns: string[];
+    workspaceIgnorePatterns: string[];
+
+    /**
+     * Array of string that are excluded from indexing of the modules (e.g. further node_modules).
+     * This patterns are ignored during indexing of the files found in the workspace.
+     * To exclude other files that are found in the node_modules, use moduleIgnorePatterns.
+     *
+     * @readonly
+     * @type {string[]}
+     * @memberof ResolverConfig
+     */
+    moduleIgnorePatterns: string[];
 
     /**
      * A length number after which the import is transformed into a multiline import.

--- a/src/extension/config/VscodeResolverConfig.ts
+++ b/src/extension/config/VscodeResolverConfig.ts
@@ -53,20 +53,39 @@ export class VscodeResolverConfig implements ResolverConfig {
     }
 
     /**
-     * Array of string that are excluded from indexing (e.g. build, out, node_modules).
-     * If those parts are found after the workspace path is striped away, the file is ignored.
+     * Array of string that are excluded from indexing of the workspace (e.g. build, out, dist).
+     * This patterns are ignored during indexing of the files found in the workspace.
+     * To exclude other files that are found in the node_modules, use moduleIgnorePatterns.
      *
      * @readonly
      * @type {string[]}
      * @memberof VscodeResolverConfig
      */
-    public get ignorePatterns(): string[] {
+    public get workspaceIgnorePatterns(): string[] {
         return this.workspaceSection.get(
-            'ignorePatterns',
+            'workspaceIgnorePatterns',
             [
-                'build/**/*',
-                'out/**/*',
-                'dist/**/*',
+                '**/build/**/*',
+                '**/out/**/*',
+                '**/dist/**/*',
+            ],
+        );
+    }
+
+    /**
+     * Array of string that are excluded from indexing of the modules (e.g. further node_modules).
+     * This patterns are ignored during indexing of the files found in the workspace.
+     * To exclude other files that are found in the node_modules, use moduleIgnorePatterns.
+     *
+     * @readonly
+     * @type {string[]}
+     * @memberof VscodeResolverConfig
+     */
+    public get moduleIgnorePatterns(): string[] {
+        return this.workspaceSection.get(
+            'moduleIgnorePatterns',
+            [
+                '**/node_modules/**/*',
             ],
         );
     }

--- a/src/extension/config/VscodeResolverConfig.ts
+++ b/src/extension/config/VscodeResolverConfig.ts
@@ -64,9 +64,9 @@ export class VscodeResolverConfig implements ResolverConfig {
         return this.workspaceSection.get(
             'ignorePatterns',
             [
-                'build',
-                'out',
-                'dist',
+                'build/**/*',
+                'out/**/*',
+                'dist/**/*',
             ],
         );
     }

--- a/src/extension/utilities/DeclarationIndexMapper.ts
+++ b/src/extension/utilities/DeclarationIndexMapper.ts
@@ -26,6 +26,12 @@ interface WorkspaceIndex {
 // TODO move did change configuration to all indices
 // TODO: update index on change of configs
 
+/**
+ * Mapping class that manages the different indices for the workspaces.
+ *
+ * @export
+ * @class DeclarationIndexMapper
+ */
 @injectable()
 export class DeclarationIndexMapper {
     public readonly onStartIndexing: Event<WorkspaceIndex>;
@@ -57,6 +63,11 @@ export class DeclarationIndexMapper {
         this.context.subscriptions.push(this._onStartIndexing);
     }
 
+    /**
+     * Init method that runs after the DI construction of the object.
+     *
+     * @memberof DeclarationIndexMapper
+     */
     @postConstruct()
     public initialize(): void {
         this.context.subscriptions.push(workspace.onDidChangeWorkspaceFolders(e => this.workspaceChanged(e)));
@@ -72,6 +83,11 @@ export class DeclarationIndexMapper {
         this.logger.info('[%s] initialized', DeclarationIndexMapper.name);
     }
 
+    /**
+     * Method to rebuild all indices in the system.
+     *
+     * @memberof DeclarationIndexMapper
+     */
     public rebuildAll(): void {
         this.logger.info(
             '[%s] rebuilding all indices',
@@ -87,6 +103,13 @@ export class DeclarationIndexMapper {
         }
     }
 
+    /**
+     * Returns the index (or undefined) for a given file URI.
+     *
+     * @param {Uri} fileUri
+     * @returns {(DeclarationIndex | undefined)}
+     * @memberof DeclarationIndexMapper
+     */
     public getIndexForFile(fileUri: Uri): DeclarationIndex | undefined {
         const workspaceFolder = workspace.getWorkspaceFolder(fileUri);
         if (!workspaceFolder || !this.indizes[workspaceFolder.uri.fsPath]) {
@@ -101,6 +124,13 @@ export class DeclarationIndexMapper {
         return this.indizes[workspaceFolder.uri.fsPath].index;
     }
 
+    /**
+     * Eventhandler that is called when the workspaces changed (i.e. some where added or removed).
+     *
+     * @private
+     * @param {WorkspaceFoldersChangeEvent} event
+     * @memberof DeclarationIndexMapper
+     */
     private workspaceChanged(event: WorkspaceFoldersChangeEvent): void {
         this.logger.info(
             '[%s] workspaces changed, adjusting indices',
@@ -135,6 +165,14 @@ export class DeclarationIndexMapper {
         }
     }
 
+    /**
+     * Helper method to initialize an index.
+     *
+     * @private
+     * @param {WorkspaceFolder} folder
+     * @returns {Promise<void>}
+     * @memberof DeclarationIndexMapper
+     */
     private async initializeIndex(folder: WorkspaceFolder): Promise<void> {
         const profiler = this.logger.startTimer();
         this.logger.debug(

--- a/test/_workspace/.gitignore
+++ b/test/_workspace/.gitignore
@@ -1,3 +1,4 @@
 !.vscode
 !node_modules
 !typings
+!out

--- a/test/_workspace/.vscode/settings.json
+++ b/test/_workspace/.vscode/settings.json
@@ -1,14 +1,4 @@
 {
-    "typescriptHero.resolver.ignorePatterns": [
-        "typescript",
-        "tslint",
-        "node_modules/typings",
-        "node_modules/typings-core",
-        "build",
-        "out",
-        "dist",
-        "resourceParser"
-    ],
     "typescriptHero.resolver.importGroups": [
         "Plains",
         "Modules",

--- a/test/_workspace/out/out.d.ts
+++ b/test/_workspace/out/out.d.ts
@@ -1,0 +1,1 @@
+export declare class MyCompiledOutClass { }

--- a/test/_workspace/package.json
+++ b/test/_workspace/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "workspace",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "fancy-library": "1.0.0",
+    "some-lib": "1.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "1.0.0"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/test/single-workspace-tests/common/helpers/DeclarationIndexHelpers.test.ts
+++ b/test/single-workspace-tests/common/helpers/DeclarationIndexHelpers.test.ts
@@ -203,6 +203,7 @@ describe('DeclarationIndexHelpers', () => {
         it('should find all relevant file in the workspace (*.ts)', async () => {
             config.resolver.resolverModeFileGlobs = config.resolver.resolverModeFileGlobs.filter(o => o.indexOf('ts') >= 0);
             const result = await findFiles(config, workfolder);
+            console.log(result);
             result.length.should.equal(49);
             (result.every(file => file.endsWith('.ts') || file.endsWith('.tsx'))).should.be.true;
             result.should.contain(join(rootPath, 'typings/globals/body-parser/index.d.ts'));
@@ -216,6 +217,7 @@ describe('DeclarationIndexHelpers', () => {
         it('should find all relevant file in the workspace (*.js)', async () => {
             config.resolver.resolverModeFileGlobs = config.resolver.resolverModeFileGlobs.filter(o => o.indexOf('js') >= 0);
             const result = await findFiles(config, workfolder);
+            console.log(result);
             result.length.should.equal(9);
             result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/addImportToDocument.js'));
             result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/jsfile.js'));
@@ -229,6 +231,7 @@ describe('DeclarationIndexHelpers', () => {
 
         it('should find all relevant file in the workspace (*.ts & *.js)', async () => {
             const result = await findFiles(config, workfolder);
+            console.log(result);
             result.length.should.equal(52);
             result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/addImportToDocument.js'));
             result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/jsfile.js'));
@@ -253,6 +256,7 @@ describe('DeclarationIndexHelpers', () => {
         it('should contain build files when configured otherwise', async () => {
             config.resolver.ignorePatterns = [];
             const result = await findFiles(config, workfolder);
+            console.log(result);
             result.should.contain(join(rootPath, 'build/app.js'));
             result.should.contain(join(rootPath, 'build/app.d.ts'));
             result.should.contain(join(rootPath, 'out/out.js'));

--- a/test/single-workspace-tests/common/helpers/DeclarationIndexHelpers.test.ts
+++ b/test/single-workspace-tests/common/helpers/DeclarationIndexHelpers.test.ts
@@ -253,7 +253,6 @@ describe.only('DeclarationIndexHelpers', () => {
         it('should contain build files when configured otherwise', async () => {
             config.resolver.ignorePatterns = [];
             const result = await findFiles(config, workfolder);
-            console.log(result);
             result.should.contain(join(rootPath, 'build/app.js'));
             result.should.contain(join(rootPath, 'build/app.d.ts'));
             result.should.contain(join(rootPath, 'out/out.js'));

--- a/test/single-workspace-tests/common/helpers/DeclarationIndexHelpers.test.ts
+++ b/test/single-workspace-tests/common/helpers/DeclarationIndexHelpers.test.ts
@@ -1,0 +1,140 @@
+import * as chai from 'chai';
+import { join } from 'path';
+import {
+    ClassDeclaration,
+    DeclarationIndex,
+    DefaultDeclaration,
+    ExternalModuleImport,
+    NamedImport,
+    NamespaceImport,
+    SymbolSpecifier,
+    TypescriptParser,
+} from 'typescript-parser';
+import { workspace } from 'vscode';
+
+import { getDeclarationsFilteredByImports } from '../../../../src/common/helpers';
+import { Container } from '../../../../src/extension/IoC';
+import { iocSymbols } from '../../../../src/extension/IoCSymbols';
+
+const should = chai.should();
+
+describe.only('DeclarationIndexHelpers', () => {
+
+    const rootPath = workspace.workspaceFolders![0].uri.fsPath;
+    const documentPath = join(rootPath, 'foobar.ts');
+
+    describe('getDeclarationsFilteredByImports()', () => {
+
+        let index: DeclarationIndex;
+
+        before(async () => {
+            const parser = Container.get<TypescriptParser>(iocSymbols.typescriptParser);
+            index = new DeclarationIndex(parser, rootPath);
+            await index.buildIndex(
+                [
+                    join(
+                        rootPath,
+                        'typings/globals/body-parser/index.d.ts',
+                    ),
+                    join(
+                        rootPath,
+                        'server/indices/MyClass.ts',
+                    ),
+                    join(
+                        rootPath,
+                        'server/indices/defaultExport/multiExport.ts',
+                    ),
+                ],
+            );
+        });
+
+        it('should return the whole list if no imports are specified', () => {
+            const result = getDeclarationsFilteredByImports(index.declarationInfos, documentPath, [], rootPath);
+            result.length.should.equal(18);
+            should.exist(result.find(d => d.declaration.name === 'Class1'));
+            should.exist(result.find(d => d.declaration.name === 'bodyParser'));
+            should.exist(result.find(d => d.declaration.name === 'MultiExportClass'));
+            should.exist(result.find(d => d.declaration.name === 'multiExport'));
+        });
+
+        it('should filter out declarations that are namespace imported', () => {
+            const imp = new NamespaceImport('body-parser', 'bodyParser');
+            const result = getDeclarationsFilteredByImports(index.declarationInfos, documentPath, [imp], rootPath);
+            result.filter(d => d.from === 'body-parser').length.should.equal(0);
+        });
+
+        it('should filter out declarations that are module imported', () => {
+            const imp = new ExternalModuleImport('body-parser', 'bodyParser');
+            const result = getDeclarationsFilteredByImports(index.declarationInfos, documentPath, [imp], rootPath);
+            result.filter(d => d.from === 'body-parser').length.should.equal(0);
+        });
+
+        it('should filter out a specifier from a named import', () => {
+            const imp = new NamedImport('/server/indices/MyClass');
+            imp.specifiers.push(new SymbolSpecifier('Class1'));
+            const result = getDeclarationsFilteredByImports(index.declarationInfos, documentPath, [imp], rootPath);
+            should.not.exist(result.find(d => d.declaration.name === 'Class1'));
+            should.exist(result.find(d => d.declaration.name === 'Class2'));
+        });
+
+        it('should filter out an aliased specifier from a named import', () => {
+            const imp = new NamedImport('/server/indices/MyClass');
+            imp.specifiers.push(new SymbolSpecifier('Class1', 'FooBar'));
+            const result = getDeclarationsFilteredByImports(index.declarationInfos, documentPath, [imp], rootPath);
+            should.not.exist(result.find(d => d.declaration.name === 'Class1'));
+            should.exist(result.find(d => d.declaration.name === 'Class2'));
+        });
+
+        it('should filter out the default declaration from a named import', () => {
+            const imp = new NamedImport('/server/indices/defaultExport/multiExport');
+            imp.defaultAlias = 'multiExport';
+            const result = getDeclarationsFilteredByImports(index.declarationInfos, documentPath, [imp], rootPath);
+            should.exist(
+                result.find(d => d.declaration instanceof ClassDeclaration && d.declaration.name === 'MultiExportClass'),
+            );
+            should.not.exist(
+                result.find(d => d.declaration instanceof DefaultDeclaration && d.declaration.name === 'multiExport'),
+            );
+        });
+
+        it('should filter out a declaration from a file with a default and a normal export', () => {
+            const imp = new NamedImport('/server/indices/defaultExport/multiExport');
+            imp.specifiers.push(new SymbolSpecifier('MultiExportClass'));
+            const result = getDeclarationsFilteredByImports(index.declarationInfos, documentPath, [imp], rootPath);
+            should.not.exist(
+                result.find(d => d.declaration instanceof ClassDeclaration && d.declaration.name === 'MultiExportClass'),
+            );
+            should.exist(
+                result.find(d => d.declaration instanceof DefaultDeclaration && d.declaration.name === 'multiExport'),
+            );
+        });
+
+    });
+
+    describe('getAbsolutLibraryName()', () => {
+
+        it('should not contain any \\');
+
+        it('should calculate the correct absolute workspace path');
+
+        it('should return the library name if not a workspace file');
+
+        it('should return the library name if the root path is not set');
+
+    });
+
+    describe('getRelativeLibraryName()', () => {
+
+        it('should not contain any \\');
+
+        it('should calculate the correct relative workspace path');
+
+        it('should return the library name if not a workspace file');
+
+        it('should return the library name if the root path is not set');
+
+    });
+
+    describe('findFiles()', () => { });
+
+});

--- a/test/single-workspace-tests/common/helpers/DeclarationIndexHelpers.test.ts
+++ b/test/single-workspace-tests/common/helpers/DeclarationIndexHelpers.test.ts
@@ -185,10 +185,13 @@ describe('DeclarationIndexHelpers', () => {
         beforeEach(() => {
             config = {
                 resolver: {
-                    ignorePatterns: [
+                    workspaceIgnorePatterns: [
                         '**/build/**/*',
                         '**/dist/**/*',
                         '**/out/**/*',
+                    ],
+                    moduleIgnorePatterns: [
+                        '**/node_modules/**/*',
                     ],
                     resolverModeFileGlobs: [
                         '**/*.ts',
@@ -203,8 +206,7 @@ describe('DeclarationIndexHelpers', () => {
         it('should find all relevant file in the workspace (*.ts)', async () => {
             config.resolver.resolverModeFileGlobs = config.resolver.resolverModeFileGlobs.filter(o => o.indexOf('ts') >= 0);
             const result = await findFiles(config, workfolder);
-            console.log(result);
-            result.length.should.equal(50);
+            result.length.should.equal(51);
             (result.every(file => file.endsWith('.ts') || file.endsWith('.tsx'))).should.be.true;
             result.should.contain(join(rootPath, 'typings/globals/body-parser/index.d.ts'));
             result.should.contain(join(rootPath, 'foobar.ts'));
@@ -212,13 +214,13 @@ describe('DeclarationIndexHelpers', () => {
             result.should.contain(join(rootPath, 'extension/extensions/codeActionExtension/empty.ts'));
             result.should.contain(join(rootPath, 'node_modules/@types/node/index.d.ts'));
             result.should.contain(join(rootPath, 'node_modules/fancy-library/index.d.ts'));
+            result.should.contain(join(rootPath, 'node_modules/some-lib/dist/SomeDeclaration.d.ts'));
         });
 
         it('should find all relevant file in the workspace (*.js)', async () => {
             config.resolver.resolverModeFileGlobs = config.resolver.resolverModeFileGlobs.filter(o => o.indexOf('js') >= 0);
             const result = await findFiles(config, workfolder);
-            console.log(result);
-            result.length.should.equal(9);
+            result.length.should.equal(10);
             result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/addImportToDocument.js'));
             result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/jsfile.js'));
             result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/jsxfile.jsx'));
@@ -226,13 +228,13 @@ describe('DeclarationIndexHelpers', () => {
             result.should.not.contain(join(rootPath, 'extension/extensions/codeActionExtension/empty.ts'));
             result.should.contain(join(rootPath, 'node_modules/@types/node/index.d.ts'));
             result.should.contain(join(rootPath, 'node_modules/fancy-library/index.d.ts'));
+            result.should.contain(join(rootPath, 'node_modules/some-lib/dist/SomeDeclaration.d.ts'));
             result.should.contain(join(rootPath, 'typings/globals/body-parser/index.d.ts'));
         });
 
         it('should find all relevant file in the workspace (*.ts & *.js)', async () => {
             const result = await findFiles(config, workfolder);
-            console.log(result);
-            result.length.should.equal(53);
+            result.length.should.equal(54);
             result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/addImportToDocument.js'));
             result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/jsfile.js'));
             result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/jsxfile.jsx'));
@@ -254,13 +256,20 @@ describe('DeclarationIndexHelpers', () => {
         });
 
         it('should contain build files when configured otherwise', async () => {
-            config.resolver.ignorePatterns = [];
+            config.resolver.workspaceIgnorePatterns = [];
             const result = await findFiles(config, workfolder);
-            console.log(result);
             result.should.contain(join(rootPath, 'build/app.js'));
             result.should.contain(join(rootPath, 'build/app.d.ts'));
             result.should.contain(join(rootPath, 'out/out.js'));
             result.should.contain(join(rootPath, 'out/out.d.ts'));
+        });
+
+        it('should not contain certain files of the modules when configured as such', async () => {
+            config.resolver.moduleIgnorePatterns = [
+                '**/dist/**/*',
+            ];
+            const result = await findFiles(config, workfolder);
+            result.should.not.contain(join(rootPath, 'node_modules/some-lib/dist/SomeDeclaration.d.ts'));
         });
 
         describe('without package.json', () => {

--- a/test/single-workspace-tests/common/helpers/DeclarationIndexHelpers.test.ts
+++ b/test/single-workspace-tests/common/helpers/DeclarationIndexHelpers.test.ts
@@ -1,3 +1,5 @@
+import { renameSync } from 'fs';
+import { ExtensionConfig } from '../../../../src/common/config';
 import * as chai from 'chai';
 import { join } from 'path';
 import {
@@ -12,13 +14,18 @@ import {
 } from 'typescript-parser';
 import { workspace } from 'vscode';
 
-import { getDeclarationsFilteredByImports } from '../../../../src/common/helpers';
+import {
+    findFiles,
+    getAbsolutLibraryName,
+    getDeclarationsFilteredByImports,
+    getRelativeLibraryName,
+} from '../../../../src/common/helpers';
 import { Container } from '../../../../src/extension/IoC';
 import { iocSymbols } from '../../../../src/extension/IoCSymbols';
 
 const should = chai.should();
 
-describe.only('DeclarationIndexHelpers', () => {
+describe('DeclarationIndexHelpers', () => {
 
     const rootPath = workspace.workspaceFolders![0].uri.fsPath;
     const documentPath = join(rootPath, 'foobar.ts');
@@ -113,28 +120,166 @@ describe.only('DeclarationIndexHelpers', () => {
 
     describe('getAbsolutLibraryName()', () => {
 
-        it('should not contain any \\');
+        it('should not contain any \\', () => {
+            const path = getAbsolutLibraryName('./server/indices/MyClass', documentPath, rootPath);
+            path.should.not.contain('\\');
+        });
 
-        it('should calculate the correct absolute workspace path');
+        it('should calculate the correct absolute workspace path', () => {
+            const path = getAbsolutLibraryName('./server/indices/MyClass', documentPath, rootPath);
+            path.should.equal('/server/indices/MyClass');
+        });
 
-        it('should return the library name if not a workspace file');
+        it('should return the library name if not a workspace file', () => {
+            const path = getAbsolutLibraryName('body-parser', documentPath, rootPath);
+            path.should.equal('body-parser');
+        });
 
-        it('should return the library name if the root path is not set');
+        it('should return the library name if the root path is not set', () => {
+            const path = getAbsolutLibraryName('./server/indices/MyClass', documentPath);
+            path.should.equal('./server/indices/MyClass');
+        });
 
     });
 
     describe('getRelativeLibraryName()', () => {
 
-        it('should not contain any \\');
+        it('should not contain any \\', () => {
+            const path = getRelativeLibraryName('/server/indices/MyClass', documentPath, rootPath);
+            path.should.not.contain('\\');
+        });
 
-        it('should calculate the correct relative workspace path');
+        it('should prepend a relative path from the same directory with ./', () => {
+            const path = getRelativeLibraryName('/server/indices/MyClass', documentPath, rootPath);
+            path.should.equal('./server/indices/MyClass');
+        });
 
-        it('should return the library name if not a workspace file');
+        it('should calculate the correct relative workspace path', () => {
+            const path = getRelativeLibraryName('/server/indices/MyClass', documentPath, rootPath);
+            path.should.equal('./server/indices/MyClass');
+        });
 
-        it('should return the library name if the root path is not set');
+        it('should calculate the correct relative workspace path 2', () => {
+            const otherDoc = join(rootPath, 'extension', 'managers', 'ClassManagerFile.ts');
+            const path = getRelativeLibraryName('/server/indices/MyClass', otherDoc, rootPath);
+            path.should.equal('../../server/indices/MyClass');
+        });
+
+        it('should return the library name if not a workspace file', () => {
+            const path = getRelativeLibraryName('body-parser', documentPath, rootPath);
+            path.should.equal('body-parser');
+        });
+
+        it('should return the library name if the root path is not set', () => {
+            const path = getRelativeLibraryName('/server/indices/MyClass', documentPath);
+            path.should.equal('/server/indices/MyClass');
+        });
 
     });
 
-    describe('findFiles()', () => { });
+    describe('findFiles()', () => {
+
+        let config: ExtensionConfig;
+        const workfolder = workspace.workspaceFolders![0];
+
+        beforeEach(() => {
+            config = {
+                resolver: {
+                    ignorePatterns: [
+                        'build/**/*',
+                        'dist/**/*',
+                        'out/**/*',
+                    ],
+                    resolverModeFileGlobs: [
+                        '**/*.ts',
+                        '**/*.tsx',
+                        '**/*.js',
+                        '**/*.jsx',
+                    ],
+                },
+            } as any as ExtensionConfig;
+        });
+
+        it('should find all relevant file in the workspace (*.ts)', async () => {
+            config.resolver.resolverModeFileGlobs = config.resolver.resolverModeFileGlobs.filter(o => o.indexOf('ts') >= 0);
+            const result = await findFiles(config, workfolder);
+            result.length.should.equal(49);
+            (result.every(file => file.endsWith('.ts') || file.endsWith('.tsx'))).should.be.true;
+            result.should.contain(join(rootPath, 'typings/globals/body-parser/index.d.ts'));
+            result.should.contain(join(rootPath, 'foobar.ts'));
+            result.should.contain(join(rootPath, 'common/ts-parsing/class.ts'));
+            result.should.contain(join(rootPath, 'extension/extensions/codeActionExtension/empty.ts'));
+            result.should.contain(join(rootPath, 'node_modules/@types/node/index.d.ts'));
+            result.should.contain(join(rootPath, 'node_modules/fancy-library/index.d.ts'));
+        });
+
+        it('should find all relevant file in the workspace (*.js)', async () => {
+            config.resolver.resolverModeFileGlobs = config.resolver.resolverModeFileGlobs.filter(o => o.indexOf('js') >= 0);
+            const result = await findFiles(config, workfolder);
+            result.length.should.equal(9);
+            result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/addImportToDocument.js'));
+            result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/jsfile.js'));
+            result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/jsxfile.jsx'));
+            result.should.not.contain(join(rootPath, 'common/ts-parsing/class.ts'));
+            result.should.not.contain(join(rootPath, 'extension/extensions/codeActionExtension/empty.ts'));
+            result.should.contain(join(rootPath, 'node_modules/@types/node/index.d.ts'));
+            result.should.contain(join(rootPath, 'node_modules/fancy-library/index.d.ts'));
+            result.should.contain(join(rootPath, 'typings/globals/body-parser/index.d.ts'));
+        });
+
+        it('should find all relevant file in the workspace (*.ts & *.js)', async () => {
+            const result = await findFiles(config, workfolder);
+            result.length.should.equal(52);
+            result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/addImportToDocument.js'));
+            result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/jsfile.js'));
+            result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/jsxfile.jsx'));
+            result.should.contain(join(rootPath, 'foobar.ts'));
+            result.should.contain(join(rootPath, 'common/ts-parsing/class.ts'));
+            result.should.contain(join(rootPath, 'common/ts-parsing/class.ts'));
+            result.should.contain(join(rootPath, 'extension/extensions/codeActionExtension/empty.ts'));
+            result.should.contain(join(rootPath, 'node_modules/@types/node/index.d.ts'));
+            result.should.contain(join(rootPath, 'node_modules/fancy-library/index.d.ts'));
+            result.should.contain(join(rootPath, 'typings/globals/body-parser/index.d.ts'));
+        });
+
+        it('should not contain build, out or dist files', async () => {
+            const result = await findFiles(config, workfolder);
+            result.should.not.contain(join(rootPath, 'build/app.js'));
+            result.should.not.contain(join(rootPath, 'build/app.d.ts'));
+            result.should.not.contain(join(rootPath, 'out/out.js'));
+            result.should.not.contain(join(rootPath, 'out/out.d.ts'));
+        });
+
+        it('should contain build files when configured otherwise', async () => {
+            config.resolver.ignorePatterns = [];
+            const result = await findFiles(config, workfolder);
+            result.should.contain(join(rootPath, 'build/app.js'));
+            result.should.contain(join(rootPath, 'build/app.d.ts'));
+            result.should.contain(join(rootPath, 'out/out.js'));
+            result.should.contain(join(rootPath, 'out/out.d.ts'));
+        });
+
+        describe('without package.json', () => {
+
+            const packageJson = join(rootPath, 'package.json');
+            const packageJsonNew = join(rootPath, 'package-new.json');
+
+            before(() => {
+                renameSync(packageJson, packageJsonNew);
+            });
+
+            after(() => {
+                renameSync(packageJsonNew, packageJson);
+            });
+
+            it('should not contain node_modules when package.json is not present', async () => {
+                const result = await findFiles(config, workfolder);
+                result.should.not.contain(join(rootPath, 'node_modules/@types/node/index.d.ts'));
+                result.should.not.contain(join(rootPath, 'node_modules/fancy-library/index.d.ts'));
+            });
+
+        });
+
+    });
 
 });

--- a/test/single-workspace-tests/common/helpers/DeclarationIndexHelpers.test.ts
+++ b/test/single-workspace-tests/common/helpers/DeclarationIndexHelpers.test.ts
@@ -1,6 +1,5 @@
-import { renameSync } from 'fs';
-import { ExtensionConfig } from '../../../../src/common/config';
 import * as chai from 'chai';
+import { renameSync } from 'fs';
 import { join } from 'path';
 import {
     ClassDeclaration,
@@ -14,6 +13,7 @@ import {
 } from 'typescript-parser';
 import { workspace } from 'vscode';
 
+import { ExtensionConfig } from '../../../../src/common/config';
 import {
     findFiles,
     getAbsolutLibraryName,

--- a/test/single-workspace-tests/common/helpers/DeclarationIndexHelpers.test.ts
+++ b/test/single-workspace-tests/common/helpers/DeclarationIndexHelpers.test.ts
@@ -25,7 +25,7 @@ import { iocSymbols } from '../../../../src/extension/IoCSymbols';
 
 const should = chai.should();
 
-describe('DeclarationIndexHelpers', () => {
+describe.only('DeclarationIndexHelpers', () => {
 
     const rootPath = workspace.workspaceFolders![0].uri.fsPath;
     const documentPath = join(rootPath, 'foobar.ts');
@@ -203,8 +203,7 @@ describe('DeclarationIndexHelpers', () => {
         it('should find all relevant file in the workspace (*.ts)', async () => {
             config.resolver.resolverModeFileGlobs = config.resolver.resolverModeFileGlobs.filter(o => o.indexOf('ts') >= 0);
             const result = await findFiles(config, workfolder);
-            console.log(result);
-            result.length.should.equal(49);
+            result.length.should.equal(50);
             (result.every(file => file.endsWith('.ts') || file.endsWith('.tsx'))).should.be.true;
             result.should.contain(join(rootPath, 'typings/globals/body-parser/index.d.ts'));
             result.should.contain(join(rootPath, 'foobar.ts'));
@@ -217,7 +216,6 @@ describe('DeclarationIndexHelpers', () => {
         it('should find all relevant file in the workspace (*.js)', async () => {
             config.resolver.resolverModeFileGlobs = config.resolver.resolverModeFileGlobs.filter(o => o.indexOf('js') >= 0);
             const result = await findFiles(config, workfolder);
-            console.log(result);
             result.length.should.equal(9);
             result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/addImportToDocument.js'));
             result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/jsfile.js'));
@@ -231,8 +229,7 @@ describe('DeclarationIndexHelpers', () => {
 
         it('should find all relevant file in the workspace (*.ts & *.js)', async () => {
             const result = await findFiles(config, workfolder);
-            console.log(result);
-            result.length.should.equal(52);
+            result.length.should.equal(53);
             result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/addImportToDocument.js'));
             result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/jsfile.js'));
             result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/jsxfile.jsx'));

--- a/test/single-workspace-tests/common/helpers/DeclarationIndexHelpers.test.ts
+++ b/test/single-workspace-tests/common/helpers/DeclarationIndexHelpers.test.ts
@@ -25,7 +25,7 @@ import { iocSymbols } from '../../../../src/extension/IoCSymbols';
 
 const should = chai.should();
 
-describe.only('DeclarationIndexHelpers', () => {
+describe('DeclarationIndexHelpers', () => {
 
     const rootPath = workspace.workspaceFolders![0].uri.fsPath;
     const documentPath = join(rootPath, 'foobar.ts');

--- a/test/single-workspace-tests/common/helpers/DeclarationIndexHelpers.test.ts
+++ b/test/single-workspace-tests/common/helpers/DeclarationIndexHelpers.test.ts
@@ -203,6 +203,7 @@ describe('DeclarationIndexHelpers', () => {
         it('should find all relevant file in the workspace (*.ts)', async () => {
             config.resolver.resolverModeFileGlobs = config.resolver.resolverModeFileGlobs.filter(o => o.indexOf('ts') >= 0);
             const result = await findFiles(config, workfolder);
+            console.log(result);
             result.length.should.equal(50);
             (result.every(file => file.endsWith('.ts') || file.endsWith('.tsx'))).should.be.true;
             result.should.contain(join(rootPath, 'typings/globals/body-parser/index.d.ts'));
@@ -216,6 +217,7 @@ describe('DeclarationIndexHelpers', () => {
         it('should find all relevant file in the workspace (*.js)', async () => {
             config.resolver.resolverModeFileGlobs = config.resolver.resolverModeFileGlobs.filter(o => o.indexOf('js') >= 0);
             const result = await findFiles(config, workfolder);
+            console.log(result);
             result.length.should.equal(9);
             result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/addImportToDocument.js'));
             result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/jsfile.js'));
@@ -229,6 +231,7 @@ describe('DeclarationIndexHelpers', () => {
 
         it('should find all relevant file in the workspace (*.ts & *.js)', async () => {
             const result = await findFiles(config, workfolder);
+            console.log(result);
             result.length.should.equal(53);
             result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/addImportToDocument.js'));
             result.should.contain(join(rootPath, 'extension/extensions/importResolveExtension/jsfile.js'));
@@ -253,6 +256,7 @@ describe('DeclarationIndexHelpers', () => {
         it('should contain build files when configured otherwise', async () => {
             config.resolver.ignorePatterns = [];
             const result = await findFiles(config, workfolder);
+            console.log(result);
             result.should.contain(join(rootPath, 'build/app.js'));
             result.should.contain(join(rootPath, 'build/app.d.ts'));
             result.should.contain(join(rootPath, 'out/out.js'));

--- a/test/single-workspace-tests/common/helpers/DeclarationIndexHelpers.test.ts
+++ b/test/single-workspace-tests/common/helpers/DeclarationIndexHelpers.test.ts
@@ -186,9 +186,9 @@ describe('DeclarationIndexHelpers', () => {
             config = {
                 resolver: {
                     ignorePatterns: [
-                        'build/**/*',
-                        'dist/**/*',
-                        'out/**/*',
+                        '**/build/**/*',
+                        '**/dist/**/*',
+                        '**/out/**/*',
                     ],
                     resolverModeFileGlobs: [
                         '**/*.ts',


### PR DESCRIPTION
- Fixes #331 

#### Description

This pr does fix the recognition of the files and correctly exclude build / dist / out from being indexed.
This does not fix the issue with the out of memory exception that happens when a way too large file is parsed. This failure has to be addressed at some other point (most likely in the parser itself)