### PR TITLE
feat(organizeImports): restore first-specifier sorting

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,14 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "develop",
+            "problemMatcher": [
+                "$tsc"
+            ]
+        }
+    ]
+}

--- a/src/extension/import-grouping/KeywordImportGroup.ts
+++ b/src/extension/import-grouping/KeywordImportGroup.ts
@@ -3,7 +3,7 @@ import { Import, StringImport } from 'typescript-parser';
 import { ConfigFactory } from '../../common/factories/index';
 import { IocDecorators } from '../IoC';
 import { iocSymbols } from '../IoCSymbols';
-import { importSort } from '../utilities/utilityFunctions';
+import { importSort, importSortByFirstSpecifier } from '../utilities/utilityFunctions';
 import { ImportGroup } from './ImportGroup';
 import { ImportGroupKeyword } from './ImportGroupKeyword';
 import { ImportGroupOrder } from './ImportGroupOrder';
@@ -22,7 +22,9 @@ export class KeywordImportGroup implements ImportGroup {
     private config: ConfigFactory;
 
     public get sortedImports(): Import[] {
-        return this.imports.sort((i1, i2) => importSort(i1, i2, this.order));
+        const config = this.config(null);
+        const sorter = config.resolver.organizeSortsByFirstSpecifier ? importSortByFirstSpecifier : importSort;
+        return this.imports.sort((i1, i2) => sorter(i1, i2, this.order));
     }
 
     constructor(public readonly keyword: ImportGroupKeyword, public readonly order: ImportGroupOrder = 'asc') { }

--- a/src/extension/import-grouping/RemainImportGroup.ts
+++ b/src/extension/import-grouping/RemainImportGroup.ts
@@ -1,12 +1,15 @@
 import { Import, StringImport } from 'typescript-parser';
 
-import { importSort } from '../utilities/utilityFunctions';
+import { ConfigFactory } from '../../common/factories';
+import { IocDecorators } from '../IoC';
+import { iocSymbols } from '../IoCSymbols';
+import { importSort, importSortByFirstSpecifier } from '../utilities/utilityFunctions';
 import { ImportGroup } from './ImportGroup';
 import { ImportGroupOrder } from './ImportGroupOrder';
 
 /**
  * Importgroup that processes all imports. Should be used if other groups don't process the import.
- * 
+ *
  * @export
  * @class RemainImportGroup
  * @implements {ImportGroup}
@@ -14,8 +17,13 @@ import { ImportGroupOrder } from './ImportGroupOrder';
 export class RemainImportGroup implements ImportGroup {
     public readonly imports: Import[] = [];
 
+    @IocDecorators.lazyInject(iocSymbols.configuration)
+    private config: ConfigFactory;
+
     public get sortedImports(): Import[] {
-        const sorted = this.imports.sort((i1, i2) => importSort(i1, i2, this.order));
+        const config = this.config(null);
+        const sorter = config.resolver.organizeSortsByFirstSpecifier ? importSortByFirstSpecifier : importSort;
+        const sorted = this.imports.sort((i1, i2) => sorter(i1, i2, this.order));
         return [
             ...sorted.filter(i => i instanceof StringImport),
             ...sorted.filter(i => !(i instanceof StringImport)),

--- a/src/extension/managers/ImportManager.ts
+++ b/src/extension/managers/ImportManager.ts
@@ -29,13 +29,7 @@ import { importRange } from '../helpers';
 import { ImportGroup } from '../import-grouping';
 import { Container } from '../IoC';
 import { iocSymbols } from '../IoCSymbols';
-import {
-    getScriptKind,
-    importGroupSortForPrecedence,
-    importSort,
-    importSortByFirstSpecifier,
-    specifierSort,
-} from '../utilities/utilityFunctions';
+import { getScriptKind, importGroupSortForPrecedence, specifierSort } from '../utilities/utilityFunctions';
 import { Logger } from '../utilities/winstonLogger';
 import { ObjectManager } from './ObjectManager';
 
@@ -276,17 +270,6 @@ export class ImportManager implements ObjectManager {
                     keep.push(actImport);
                 }
             }
-        }
-
-        if (!this.config.resolver.disableImportSorting) {
-            const sorter = this.config.resolver.organizeSortsByFirstSpecifier
-                ? importSortByFirstSpecifier
-                : importSort;
-
-            keep = [
-                ...keep.filter(o => o instanceof StringImport).sort(sorter),
-                ...keep.filter(o => !(o instanceof StringImport)).sort(sorter),
-            ];
         }
 
         for (const group of this.importGroups) {

--- a/test/_workspace/extension/import-grouping/first-specifier-imports.ts
+++ b/test/_workspace/extension/import-grouping/first-specifier-imports.ts
@@ -1,0 +1,13 @@
+// Modules / RegExp
+
+import { AnotherModuleFoo as MuchFurtherSorted } from 'anotherLib';
+import ModuleFoobar from 'myLib';
+import { Foobar, Genero } from 'someLib';
+import { AnotherFoobar } from 'someOtherLib';
+
+// Workspace
+
+import { AnotherModuleFoo as MuchFurtherSortedWS } from './anotherWS';
+import ModuleFoobarWS from './myWS';
+import { FoobarWS, GeneroWS } from './someWS';
+import { AnotherFoobarWS } from './someOtherWS';

--- a/test/single-workspace-tests/extension/import-grouping/KeywordImportGroup.test.ts
+++ b/test/single-workspace-tests/extension/import-grouping/KeywordImportGroup.test.ts
@@ -15,6 +15,7 @@ describe('KeywordImportGroup', () => {
 
     const rootPath = workspace.workspaceFolders![0].uri.fsPath;
     let file: File;
+    let specifiersFile: File;
     let importGroup: KeywordImportGroup;
     let generator: TypescriptCodeGenerator;
 
@@ -25,6 +26,13 @@ describe('KeywordImportGroup', () => {
             join(
                 rootPath,
                 'extension/import-grouping/imports.ts',
+            ),
+            rootPath,
+        );
+        specifiersFile = await parser.parseFile(
+            join(
+                rootPath,
+                'extension/import-grouping/first-specifier-imports.ts',
             ),
             rootPath,
         );
@@ -52,29 +60,72 @@ describe('KeywordImportGroup', () => {
             file.imports.map(i => importGroup.processImport(i)).should.deep.equal([false, false, false, false, true, true]);
         });
 
-        it('should generate the correct typescript (asc)', () => {
-            for (const imp of file.imports) {
-                if (importGroup.processImport(imp)) {
-                    continue;
+        describe('when sorting by module paths', () => {
+            it('should generate the correct typescript (asc)', () => {
+                for (const imp of file.imports) {
+                    if (importGroup.processImport(imp)) {
+                        continue;
+                    }
                 }
-            }
-            generator.generate(importGroup as any).should.equal(
-                `import { AnotherModuleFoo } from 'anotherLib';\n` +
-                `import { ModuleFoobar } from 'myLib';\n`,
-            );
+                generator.generate(importGroup as any).should.equal(
+                    `import { AnotherModuleFoo } from 'anotherLib';\n` +
+                    `import { ModuleFoobar } from 'myLib';\n`,
+                );
+            });
+
+            it('should generate the correct typescript (desc)', () => {
+                (importGroup as any).order = 'desc';
+                for (const imp of file.imports) {
+                    if (importGroup.processImport(imp)) {
+                        continue;
+                    }
+                }
+                generator.generate(importGroup as any).should.equal(
+                    `import { ModuleFoobar } from 'myLib';\n` +
+                    `import { AnotherModuleFoo } from 'anotherLib';\n`,
+                );
+            });
         });
 
-        it('should generate the correct typescript (desc)', () => {
-            (importGroup as any).order = 'desc';
-            for (const imp of file.imports) {
-                if (importGroup.processImport(imp)) {
-                    continue;
+        describe('when sorting by first specifiers', () => {
+            before(async () => {
+                const config = workspace.getConfiguration('typescriptHero');
+                await config.update('resolver.organizeSortsByFirstSpecifier', true);
+            });
+
+            after(async () => {
+                const config = workspace.getConfiguration('typescriptHero');
+                await config.update('resolver.organizeSortsByFirstSpecifier', false);
+            });
+
+            it('should generate the correct typescript (asc)', () => {
+                for (const imp of specifiersFile.imports) {
+                    if (importGroup.processImport(imp)) {
+                        continue;
+                    }
                 }
-            }
-            generator.generate(importGroup as any).should.equal(
-                `import { ModuleFoobar } from 'myLib';\n` +
-                `import { AnotherModuleFoo } from 'anotherLib';\n`,
-            );
+                generator.generate(importGroup as any).should.equal(
+                    "import { AnotherFoobar } from 'someOtherLib';\n" +
+                    "import { Foobar, Genero } from 'someLib';\n" +
+                    "import ModuleFoobar from 'myLib';\n" +
+                    "import { AnotherModuleFoo as MuchFurtherSorted } from 'anotherLib';\n"
+                );
+            });
+
+            it('should generate the correct typescript (desc)', () => {
+                (importGroup as any).order = 'desc';
+                for (const imp of specifiersFile.imports) {
+                    if (importGroup.processImport(imp)) {
+                        continue;
+                    }
+                }
+                generator.generate(importGroup as any).should.equal(
+                    "import { AnotherModuleFoo as MuchFurtherSorted } from 'anotherLib';\n" +
+                    "import ModuleFoobar from 'myLib';\n" +
+                    "import { Foobar, Genero } from 'someLib';\n" +
+                    "import { AnotherFoobar } from 'someOtherLib';\n"
+                );
+            });
         });
 
     });
@@ -125,7 +176,6 @@ describe('KeywordImportGroup', () => {
                 `import './workspaceSideEffectLib';\n`,
             );
         });
-
     });
 
     describe(`keyword "Workspace"`, () => {
@@ -150,29 +200,72 @@ describe('KeywordImportGroup', () => {
             file.imports.map(i => importGroup.processImport(i)).should.deep.equal([false, false, true, true, false, false]);
         });
 
-        it('should generate the correct typescript (asc)', () => {
-            for (const imp of file.imports) {
-                if (importGroup.processImport(imp)) {
-                    continue;
+        describe('when sorting by module paths', () => {
+            it('should generate the correct typescript (asc)', () => {
+                for (const imp of file.imports) {
+                    if (importGroup.processImport(imp)) {
+                        continue;
+                    }
                 }
-            }
-            generator.generate(importGroup as any).should.equal(
-                `import { AnotherFoobar } from './anotherFile';\n` +
-                `import { Foobar } from './myFile';\n`,
-            );
+                generator.generate(importGroup as any).should.equal(
+                    `import { AnotherFoobar } from './anotherFile';\n` +
+                    `import { Foobar } from './myFile';\n`,
+                );
+            });
+
+            it('should generate the correct typescript (desc)', () => {
+                (importGroup as any).order = 'desc';
+                for (const imp of file.imports) {
+                    if (importGroup.processImport(imp)) {
+                        continue;
+                    }
+                }
+                generator.generate(importGroup as any).should.equal(
+                    `import { Foobar } from './myFile';\n` +
+                    `import { AnotherFoobar } from './anotherFile';\n`,
+                );
+            });
         });
 
-        it('should generate the correct typescript (desc)', () => {
-            (importGroup as any).order = 'desc';
-            for (const imp of file.imports) {
-                if (importGroup.processImport(imp)) {
-                    continue;
+        describe('when sorting by first specifiers', () => {
+            before(async () => {
+                const config = workspace.getConfiguration('typescriptHero');
+                await config.update('resolver.organizeSortsByFirstSpecifier', true);
+            });
+
+            after(async () => {
+                const config = workspace.getConfiguration('typescriptHero');
+                await config.update('resolver.organizeSortsByFirstSpecifier', false);
+            });
+
+            it('should generate the correct typescript (asc)', () => {
+                for (const imp of specifiersFile.imports) {
+                    if (importGroup.processImport(imp)) {
+                        continue;
+                    }
                 }
-            }
-            generator.generate(importGroup as any).should.equal(
-                `import { Foobar } from './myFile';\n` +
-                `import { AnotherFoobar } from './anotherFile';\n`,
-            );
+                generator.generate(importGroup as any).should.equal(
+                    "import { AnotherFoobarWS } from './someOtherWS';\n" +
+                    "import { FoobarWS, GeneroWS } from './someWS';\n" +
+                    "import ModuleFoobarWS from './myWS';\n" +
+                    "import { AnotherModuleFoo as MuchFurtherSortedWS } from './anotherWS';\n"
+                );
+            });
+
+            it('should generate the correct typescript (desc)', () => {
+                (importGroup as any).order = 'desc';
+                for (const imp of specifiersFile.imports) {
+                    if (importGroup.processImport(imp)) {
+                        continue;
+                    }
+                }
+                generator.generate(importGroup as any).should.equal(
+                    "import { AnotherModuleFoo as MuchFurtherSortedWS } from './anotherWS';\n" +
+                    "import ModuleFoobarWS from './myWS';\n" +
+                    "import { FoobarWS, GeneroWS } from './someWS';\n" +
+                    "import { AnotherFoobarWS } from './someOtherWS';\n"
+                );
+            });
         });
 
     });

--- a/test/single-workspace-tests/extension/import-grouping/RemainImportGroup.test.ts
+++ b/test/single-workspace-tests/extension/import-grouping/RemainImportGroup.test.ts
@@ -14,6 +14,7 @@ describe('RemainImportGroup', () => {
 
     const rootPath = workspace.workspaceFolders![0].uri.fsPath;
     let file: File;
+    let specifiersFile: File;
     let importGroup: RemainImportGroup;
     let generator: TypescriptCodeGenerator;
 
@@ -27,6 +28,13 @@ describe('RemainImportGroup', () => {
             ),
             rootPath,
         );
+        specifiersFile = await parser.parseFile(
+            join(
+                rootPath,
+                'extension/import-grouping/first-specifier-imports.ts',
+            ),
+            rootPath,
+        );
     });
 
     beforeEach(() => {
@@ -37,37 +45,87 @@ describe('RemainImportGroup', () => {
         file.imports.map(i => importGroup.processImport(i)).should.deep.equal([true, true, true, true, true, true]);
     });
 
-    it('should generate the correct typescript (asc)', () => {
-        for (const imp of file.imports) {
-            if (importGroup.processImport(imp)) {
-                continue;
+    describe('when sorting by module paths', () => {
+        it('should generate the correct typescript (asc)', () => {
+            for (const imp of file.imports) {
+                if (importGroup.processImport(imp)) {
+                    continue;
+                }
             }
-        }
-        generator.generate(importGroup as any).should.equal(
-            `import './workspaceSideEffectLib';\n` +
-            `import 'sideEffectLib';\n` +
-            `import { AnotherFoobar } from './anotherFile';\n` +
-            `import { Foobar } from './myFile';\n` +
-            `import { AnotherModuleFoo } from 'anotherLib';\n` +
-            `import { ModuleFoobar } from 'myLib';\n`,
-        );
+            generator.generate(importGroup as any).should.equal(
+                `import './workspaceSideEffectLib';\n` +
+                `import 'sideEffectLib';\n` +
+                `import { AnotherFoobar } from './anotherFile';\n` +
+                `import { Foobar } from './myFile';\n` +
+                `import { AnotherModuleFoo } from 'anotherLib';\n` +
+                `import { ModuleFoobar } from 'myLib';\n`,
+            );
+        });
+
+        it('should generate the correct typescript (desc)', () => {
+            (importGroup as any).order = 'desc';
+            for (const imp of file.imports) {
+                if (importGroup.processImport(imp)) {
+                    continue;
+                }
+            }
+            generator.generate(importGroup as any).should.equal(
+                `import 'sideEffectLib';\n` +
+                `import './workspaceSideEffectLib';\n` +
+                `import { ModuleFoobar } from 'myLib';\n` +
+                `import { AnotherModuleFoo } from 'anotherLib';\n` +
+                `import { Foobar } from './myFile';\n` +
+                `import { AnotherFoobar } from './anotherFile';\n`,
+            );
+        });
     });
 
-    it('should generate the correct typescript (desc)', () => {
-        (importGroup as any).order = 'desc';
-        for (const imp of file.imports) {
-            if (importGroup.processImport(imp)) {
-                continue;
-            }
-        }
-        generator.generate(importGroup as any).should.equal(
-            `import 'sideEffectLib';\n` +
-            `import './workspaceSideEffectLib';\n` +
-            `import { ModuleFoobar } from 'myLib';\n` +
-            `import { AnotherModuleFoo } from 'anotherLib';\n` +
-            `import { Foobar } from './myFile';\n` +
-            `import { AnotherFoobar } from './anotherFile';\n`,
-        );
-    });
+    describe('when sorting by first specifiers', () => {
+        before(async () => {
+            const config = workspace.getConfiguration('typescriptHero');
+            await config.update('resolver.organizeSortsByFirstSpecifier', true);
+        });
 
+        after(async () => {
+            const config = workspace.getConfiguration('typescriptHero');
+            await config.update('resolver.organizeSortsByFirstSpecifier', false);
+        });
+
+        it('should generate the correct typescript (asc)', () => {
+            for (const imp of specifiersFile.imports) {
+                if (importGroup.processImport(imp)) {
+                    continue;
+                }
+            }
+            generator.generate(importGroup as any).should.equal(
+                "import { AnotherFoobar } from 'someOtherLib';\n" +
+                "import { AnotherFoobarWS } from './someOtherWS';\n" +
+                "import { Foobar, Genero } from 'someLib';\n" +
+                "import { FoobarWS, GeneroWS } from './someWS';\n" +
+                "import ModuleFoobar from 'myLib';\n" +
+                "import ModuleFoobarWS from './myWS';\n" +
+                "import { AnotherModuleFoo as MuchFurtherSorted } from 'anotherLib';\n" +
+                "import { AnotherModuleFoo as MuchFurtherSortedWS } from './anotherWS';\n"
+            );
+        });
+
+        it('should generate the correct typescript (desc)', () => {
+            (importGroup as any).order = 'desc';
+            for (const imp of specifiersFile.imports) {
+                if (importGroup.processImport(imp)) {
+                    continue;
+                }
+            }
+            generator.generate(importGroup as any).should.equal(
+                "import { AnotherModuleFoo as MuchFurtherSortedWS } from './anotherWS';\n" +
+                "import { AnotherModuleFoo as MuchFurtherSorted } from 'anotherLib';\n" +
+                "import ModuleFoobarWS from './myWS';\n" +
+                "import ModuleFoobar from 'myLib';\n" +
+                "import { FoobarWS, GeneroWS } from './someWS';\n" +
+                "import { Foobar, Genero } from 'someLib';\n" +
+                "import { AnotherFoobarWS } from './someOtherWS';\n" +
+                "import { AnotherFoobar } from 'someOtherLib';\n"
+            );
+        });
+    });
 });

--- a/test/single-workspace-tests/extension/managers/ImportManager.test.ts
+++ b/test/single-workspace-tests/extension/managers/ImportManager.test.ts
@@ -574,50 +574,6 @@ describe('ImportManager', () => {
             const names = (ctrl as any).imports.map((l) => l.libraryName)
             names.should.deep.equal(['../plain.ts', 'react', 'some-regular-module', 'cool-library', 'cooler-library/items', '../../server/indices'])
         });
-
-        describe('resolver.organizeSortsByFirstSpecifier: true', () => {
-            before(async () => {
-                const config = workspace.getConfiguration('typescriptHero');
-                await config.update('resolver.organizeSortsByFirstSpecifier', true);
-            });
-
-            after(async () => {
-                const config = workspace.getConfiguration('typescriptHero');
-                await config.update('resolver.organizeSortsByFirstSpecifier', false);
-            });
-
-            it('should sort imports by first specifier/alias', async () => {
-                const demoSource = `
-                import { Foobar, Genero } from 'someLib';
-                import { AnotherFoobar } from 'someOtherLib';
-                import ModuleFoobar from 'myLib';
-                import { AnotherModuleFoo as MuchFurtherSorted } from 'anotherLib';
-
-                console.log(AnotherFoobar, Foobar, Genero, ModuleFoobar, MuchFurtherSorted)
-                `.replace(/\n[ \t]+/g, '\n').trim();
-
-                await window.activeTextEditor!.edit((builder) => {
-                    builder.delete(new Range(
-                        new Position(0, 0),
-                        document.lineAt(document.lineCount - 1).rangeIncludingLineBreak.end,
-                    ));
-                    builder.insert(new Position(0, 0), demoSource);
-                });
-
-                const ctrl = await ImportManager.create(document);
-
-                (ctrl as any).imports[0].libraryName.should.equal('someLib');
-
-                ctrl.organizeImports();
-
-                (ctrl as any).imports.map((i) => i.libraryName).should.deep.equal([
-                    'someOtherLib', // { AnotherFoobar }
-                    'someLib',      // { Foobar, Genero }
-                    'myLib',        // ModuleFoobar
-                    'anotherLib',   // { AnotherModuleFoo as MuchFurtherSorted }
-                ]);
-            })
-        })
     });
 
     describe('commit()', () => {


### PR DESCRIPTION
- Should fix #369 once tests can pass properly.

#### Description

This is achieved by moving in-group sorting responsibility to
import groups, instead of trying to achieve this in the import
manager, only to be overridden by the groups' `sortedImports` getter
inside their `generate()` calls, as discussed in
buehler/typescript-hero#369.

This isn't marked as closing yet, as I am facing an issue with
manual testing going fine, but automated testing VSC debug target
failing to locate the IocDecorators export, apparently, thereby
b0rking on `lazyInject` for config DI.  I need input from @buehler
on this.

#### Diff online viewing protip

As tests have several parts now wrapped in their own `describe` blocks, this PR's diff is best viewed by appending a `?w=1` query string to the GitHub URL for it, so as not to get verbose diffs due to indentation changes. [Try this on for size](https://github.com/buehler/typescript-hero/pull/370/files?w=1)
  