### PR TITLE
fix(organize-imports): Don't reorder shebang and block comment

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -50,7 +50,7 @@
       "env": {
         "EXT_DEBUG": "true",
         "LOCAL_TEST": "true",
-        "COVERAGE": "true",
+        "COVERAGE": "",
         "CHAI_JEST_SNAPSHOT_UPDATE_ALL": ""
       },
       "stopOnEntry": false,
@@ -74,7 +74,7 @@
       "env": {
         "EXT_DEBUG": "true",
         "LOCAL_TEST": "true",
-        "COVERAGE": "true",
+        "COVERAGE": "",
         "CHAI_JEST_SNAPSHOT_UPDATE_ALL": ""
       },
       "stopOnEntry": false,

--- a/src/utilities/utility-functions.ts
+++ b/src/utilities/utility-functions.ts
@@ -320,7 +320,7 @@ export function getRelativeLibraryName(library: string, actualFilePath: string, 
   return toPosix(relativePath);
 }
 
-const REGEX_IGNORED_LINE = /^\s*(?:\/\/|\/\*\*|\*\/|\*|(['"])use strict\1)/;
+const REGEX_IGNORED_LINE = /^\s*(?:\/\/|\/\*|\*\/|\*|(['"])use strict\1)/;
 
 /**
  * Calculate the position, where a new import should be inserted.

--- a/src/utilities/utility-functions.ts
+++ b/src/utilities/utility-functions.ts
@@ -320,7 +320,7 @@ export function getRelativeLibraryName(library: string, actualFilePath: string, 
   return toPosix(relativePath);
 }
 
-const REGEX_IGNORED_LINE = /^\s*(?:\/\/|\/\*|\*\/|\*|(['"])use strict\1)/;
+const REGEX_IGNORED_LINE = /^\s*(?:\/\/|\/\*|\*\/|\*|#!|(['"])use strict\1)/;
 
 /**
  * Calculate the position, where a new import should be inserted.

--- a/test/tests/imports/__snapshots__/import-appender.test.ts.snap
+++ b/test/tests/imports/__snapshots__/import-appender.test.ts.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ImportAppender import-appender-file.ts should add a double normal named import 1`] = `
+"import { MyClass, MyClass2 } from '../lib';
+"
+`;
+
+exports[`ImportAppender import-appender-file.ts should add a normal default import 1`] = `
+"import defaultDec from '../lib';
+"
+`;
+
+exports[`ImportAppender import-appender-file.ts should add a normal named import 1`] = `
+"import { MyClass } from '../lib';
+"
+`;
+
+exports[`ImportAppender import-appender-file.ts should add an import below a block comment 1`] = `
+"/* 
+ * copy right by me!
+ */
+import { MyClass } from '../lib';
+"
+`;
+
+exports[`ImportAppender import-appender-file.ts should add an import below a comment 1`] = `
+"// my fancy comment
+import { MyClass } from '../lib';
+"
+`;
+
+exports[`ImportAppender import-appender-file.ts should add an import below a jsdoc comment 1`] = `
+"/** 
+ * js documentation!
+ */
+import { MyClass } from '../lib';
+"
+`;
+
+exports[`ImportAppender import-appender-file.ts should add an import below a shebang 1`] = `
+"#! /usr/bin/env node
+import { MyClass } from '../lib';
+"
+`;
+
+exports[`ImportAppender import-appender-file.ts should add an import below a use strict 1`] = `
+"\\"use strict\\"
+import { MyClass } from '../lib';
+"
+`;

--- a/test/tests/imports/import-appender.test.ts
+++ b/test/tests/imports/import-appender.test.ts
@@ -1,29 +1,32 @@
 import { join } from 'path';
+import { ClassDeclaration, DeclarationInfo, DefaultDeclaration, File } from 'typescript-parser';
 import { Position, Range, TextDocument, Uri, window, workspace } from 'vscode';
 
-import { ImportOrganizer } from '../../../src/imports';
+import { ImportAppender } from '../../../src/imports';
 import ioc from '../../../src/ioc';
 import iocSymbols from '../../../src/ioc-symbols';
+import { expect } from '../setup';
 
-describe('ImportAppender', () => {
+describe.only('ImportAppender', () => {
 
   describe('import-appender-file.ts', () => {
 
     const rootPath = workspace.workspaceFolders![0].uri.fsPath;
     const file = Uri.file(join(rootPath, 'imports', 'import-appender-file.ts'));
     let document: TextDocument;
-    let extension: any;
+    let extension: { addImportToDocument(declaration: DeclarationInfo): Promise<boolean> };
 
     before(async () => {
       document = await workspace.openTextDocument(file);
       await window.showTextDocument(document);
 
-      extension = new ImportOrganizer(
+      extension = new ImportAppender(
         ioc.get(iocSymbols.extensionContext),
         ioc.get(iocSymbols.logger),
-        ioc.get(iocSymbols.configuration),
         ioc.get(iocSymbols.importManager),
-      );
+        ioc.get(iocSymbols.declarationManager),
+        ioc.get(iocSymbols.parser),
+      ) as any;
     });
 
     afterEach(async () => {
@@ -33,6 +36,104 @@ describe('ImportAppender', () => {
           document.lineAt(document.lineCount - 1).rangeIncludingLineBreak.end,
         ));
       });
+    });
+
+    it('should add a normal named import', async () => {
+      await extension.addImportToDocument({
+        from: '/lib',
+        declaration: new ClassDeclaration('MyClass', true, 0, 0),
+      });
+      expect(window.activeTextEditor!.document.getText()).to.matchSnapshot();
+    });
+
+    it('should add a double normal named import', async () => {
+      await extension.addImportToDocument({
+        from: '/lib',
+        declaration: new ClassDeclaration('MyClass', true, 0, 0),
+      });
+      await extension.addImportToDocument({
+        from: '/lib',
+        declaration: new ClassDeclaration('MyClass2', true, 0, 0),
+      });
+      expect(window.activeTextEditor!.document.getText()).to.matchSnapshot();
+    });
+
+    it('should add a normal default import', async () => {
+      await extension.addImportToDocument({
+        from: '/lib',
+        declaration: new DefaultDeclaration('defaultDec', new File(file.fsPath, rootPath, 0, 0), 0, 0),
+      });
+      expect(window.activeTextEditor!.document.getText()).to.matchSnapshot();
+    });
+
+    it('should add an import below a comment', async () => {
+      await window.activeTextEditor!.edit((builder) => {
+        builder.insert(
+          new Position(0, 0),
+          `// my fancy comment\n`,
+        );
+      });
+      await extension.addImportToDocument({
+        from: '/lib',
+        declaration: new ClassDeclaration('MyClass', true, 0, 0),
+      });
+      expect(window.activeTextEditor!.document.getText()).to.matchSnapshot();
+    });
+
+    it('should add an import below a block comment', async () => {
+      await window.activeTextEditor!.edit((builder) => {
+        builder.insert(
+          new Position(0, 0),
+          `/* \n * copy right by me!\n */\n`,
+        );
+      });
+      await extension.addImportToDocument({
+        from: '/lib',
+        declaration: new ClassDeclaration('MyClass', true, 0, 0),
+      });
+      expect(window.activeTextEditor!.document.getText()).to.matchSnapshot();
+    });
+
+    it('should add an import below a jsdoc comment', async () => {
+      await window.activeTextEditor!.edit((builder) => {
+        builder.insert(
+          new Position(0, 0),
+          `/** \n * js documentation!\n */\n`,
+        );
+      });
+      await extension.addImportToDocument({
+        from: '/lib',
+        declaration: new ClassDeclaration('MyClass', true, 0, 0),
+      });
+      expect(window.activeTextEditor!.document.getText()).to.matchSnapshot();
+    });
+
+    it('should add an import below a shebang', async () => {
+      await window.activeTextEditor!.edit((builder) => {
+        builder.insert(
+          new Position(0, 0),
+          `#! /usr/bin/env node\n`,
+        );
+      });
+      await extension.addImportToDocument({
+        from: '/lib',
+        declaration: new ClassDeclaration('MyClass', true, 0, 0),
+      });
+      expect(window.activeTextEditor!.document.getText()).to.matchSnapshot();
+    });
+
+    it('should add an import below a use strict', async () => {
+      await window.activeTextEditor!.edit((builder) => {
+        builder.insert(
+          new Position(0, 0),
+          `"use strict"\n`,
+        );
+      });
+      await extension.addImportToDocument({
+        from: '/lib',
+        declaration: new ClassDeclaration('MyClass', true, 0, 0),
+      });
+      expect(window.activeTextEditor!.document.getText()).to.matchSnapshot();
     });
 
   });

--- a/test/tests/imports/import-appender.test.ts
+++ b/test/tests/imports/import-appender.test.ts
@@ -1,0 +1,40 @@
+import { join } from 'path';
+import { Position, Range, TextDocument, Uri, window, workspace } from 'vscode';
+
+import { ImportOrganizer } from '../../../src/imports';
+import ioc from '../../../src/ioc';
+import iocSymbols from '../../../src/ioc-symbols';
+
+describe('ImportAppender', () => {
+
+  describe('import-appender-file.ts', () => {
+
+    const rootPath = workspace.workspaceFolders![0].uri.fsPath;
+    const file = Uri.file(join(rootPath, 'imports', 'import-appender-file.ts'));
+    let document: TextDocument;
+    let extension: any;
+
+    before(async () => {
+      document = await workspace.openTextDocument(file);
+      await window.showTextDocument(document);
+
+      extension = new ImportOrganizer(
+        ioc.get(iocSymbols.extensionContext),
+        ioc.get(iocSymbols.logger),
+        ioc.get(iocSymbols.configuration),
+        ioc.get(iocSymbols.importManager),
+      );
+    });
+
+    afterEach(async () => {
+      await window.activeTextEditor!.edit((builder) => {
+        builder.delete(new Range(
+          new Position(0, 0),
+          document.lineAt(document.lineCount - 1).rangeIncludingLineBreak.end,
+        ));
+      });
+    });
+
+  });
+
+});

--- a/test/tests/imports/import-appender.test.ts
+++ b/test/tests/imports/import-appender.test.ts
@@ -7,7 +7,7 @@ import ioc from '../../../src/ioc';
 import iocSymbols from '../../../src/ioc-symbols';
 import { expect } from '../setup';
 
-describe.only('ImportAppender', () => {
+describe('ImportAppender', () => {
 
   describe('import-appender-file.ts', () => {
 

--- a/test/tests/utilities/__snapshots__/utility-functions.test.ts.snap
+++ b/test/tests/utilities/__snapshots__/utility-functions.test.ts.snap
@@ -7,6 +7,13 @@ Object {
 }
 `;
 
+exports[`utility functions getImportInsertPosition() should return correct position for js block comment open 1`] = `
+Object {
+  "character": 0,
+  "line": 1,
+}
+`;
+
 exports[`utility functions getImportInsertPosition() should return correct position for jsdoc comment close 1`] = `
 Object {
   "character": 0,
@@ -22,6 +29,13 @@ Object {
 `;
 
 exports[`utility functions getImportInsertPosition() should return correct position for jsdoc comment open 1`] = `
+Object {
+  "character": 0,
+  "line": 1,
+}
+`;
+
+exports[`utility functions getImportInsertPosition() should return correct position for shebang (#!) 1`] = `
 Object {
   "character": 0,
   "line": 1,

--- a/test/tests/utilities/utility-functions.test.ts
+++ b/test/tests/utilities/utility-functions.test.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../src/utilities/utility-functions';
 import { expect } from '../setup';
 
-describe.only('utility functions', () => {
+describe('utility functions', () => {
 
   describe('getImportInsertPosition()', () => {
 

--- a/test/tests/utilities/utility-functions.test.ts
+++ b/test/tests/utilities/utility-functions.test.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../src/utilities/utility-functions';
 import { expect } from '../setup';
 
-describe('utility functions', () => {
+describe.only('utility functions', () => {
 
   describe('getImportInsertPosition()', () => {
 
@@ -57,6 +57,13 @@ describe('utility functions', () => {
       expect(pos).to.matchSnapshot();
     });
 
+    it('should return correct position for js block comment open', () => {
+      const pos = getImportInsertPosition({
+        document: new MockDocument('/* yay\n'),
+      } as any);
+      expect(pos).to.matchSnapshot();
+    });
+
     it('should return correct position for jsdoc comment line', () => {
       const pos = getImportInsertPosition({
         document: new MockDocument(' * jsdoc line\n'),
@@ -67,6 +74,13 @@ describe('utility functions', () => {
     it('should return correct position for jsdoc comment close', () => {
       const pos = getImportInsertPosition({
         document: new MockDocument('*/\n'),
+      } as any);
+      expect(pos).to.matchSnapshot();
+    });
+
+    it('should return correct position for shebang (#!)', () => {
+      const pos = getImportInsertPosition({
+        document: new MockDocument('#!\n'),
       } as any);
       expect(pos).to.matchSnapshot();
     });


### PR DESCRIPTION
- Fixes #412
- Fixes #409

#### Description

- Adding shebang to the list of excluded line comments on the top of the file
- Adding `/*` instead of `/**` to the list of excluded line comments on the top of the line
