### PR TITLE
Ensure Plain imports will always be at top of file

### DIFF
--- a/src/utilities/utility-functions.ts
+++ b/src/utilities/utility-functions.ts
@@ -27,7 +27,7 @@ import {
 import { toPosix } from 'typescript-parser/utilities/PathHelpers';
 import { CompletionItemKind, Position, TextEditor } from 'vscode';
 
-import { ImportGroup, RegexImportGroup } from '../imports/import-grouping';
+import { ImportGroup, ImportGroupKeyword, KeywordImportGroup, RegexImportGroup } from '../imports/import-grouping';
 
 /**
  * String-Sort function.
@@ -65,7 +65,7 @@ export function importGroupSortForPrecedence(importGroups: ImportGroup[]): Impor
   const regexGroups: ImportGroup[] = [];
   const otherGroups: ImportGroup[] = [];
   for (const ig of importGroups) {
-    if (ig instanceof KeywordImportGroup && ig.keyword === ImportGroupKeyword.Plains) {
+    if (ig instanceof KeywordImportGroup && (ig as KeywordImportGroup).keyword === ImportGroupKeyword.Plains) {
       plainsGroups.push(ig);
     } else {
       (ig instanceof RegexImportGroup ? regexGroups : otherGroups).push(ig);

--- a/src/utilities/utility-functions.ts
+++ b/src/utilities/utility-functions.ts
@@ -61,12 +61,17 @@ export function stringSort(strA: string, strB: string, order: 'asc' | 'desc' = '
 * @returns {ImportGroup[]} The same list, with Regex import groups appearing first.
 */
 export function importGroupSortForPrecedence(importGroups: ImportGroup[]): ImportGroup[] {
+  const plainsGroups: ImportGroup[] = [];
   const regexGroups: ImportGroup[] = [];
   const otherGroups: ImportGroup[] = [];
   for (const ig of importGroups) {
-    (ig instanceof RegexImportGroup ? regexGroups : otherGroups).push(ig);
+    if (ig instanceof KeywordImportGroup && ig.keyword === ImportGroupKeyword.Plains) {
+      plainsGroups.push(ig);
+    } else {
+      (ig instanceof RegexImportGroup ? regexGroups : otherGroups).push(ig);
+    }
   }
-  return regexGroups.concat(otherGroups);
+  return plainsGroups.concat(regexGroups.concat(otherGroups));
 }
 
 /**


### PR DESCRIPTION
<list of issues that are closed feature or fixed bug>

- Fixes #454 
- Closes #454 

#### Description

Currently, Plain imports can get caught in Regex groups. However, plain imports should always be at the top of the file to avoid unwanted bugs (e.g. a plain import initializes something, if another import gets called before and depends on it then it will fail).


Please let me know if I should change anything :)